### PR TITLE
Add smbv1

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,244 @@
+# Remove the line below if you want to inherit .editorconfig settings from higher directories
+root = true
+
+# C# files
+[*.cs]
+
+#### Core EditorConfig Options ####
+
+# Indentation and spacing
+indent_size = 4
+indent_style = space
+tab_width = 4
+
+# New line preferences
+end_of_line = crlf
+insert_final_newline = false
+
+#### .NET Code Actions ####
+
+# Type members
+dotnet_hide_advanced_members = false
+dotnet_member_insertion_location = with_other_members_of_the_same_kind
+dotnet_property_generation_behavior = prefer_throwing_properties
+
+# Symbol search
+dotnet_search_reference_assemblies = true
+
+#### .NET Coding Conventions ####
+
+# Organize usings
+dotnet_separate_import_directive_groups = false
+dotnet_sort_system_directives_first = false
+file_header_template = unset
+
+# this. and Me. preferences
+dotnet_style_qualification_for_event = false
+dotnet_style_qualification_for_field = false
+dotnet_style_qualification_for_method = false
+dotnet_style_qualification_for_property = false
+
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true
+dotnet_style_predefined_type_for_member_access = true
+
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity
+
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members
+
+# Expression-level preferences
+dotnet_prefer_system_hash_code = true
+dotnet_style_coalesce_expression = true
+dotnet_style_collection_initializer = true
+dotnet_style_explicit_tuple_names = true
+dotnet_style_namespace_match_folder = true
+dotnet_style_null_propagation = true
+dotnet_style_object_initializer = true
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+dotnet_style_prefer_auto_properties = true
+dotnet_style_prefer_collection_expression = when_types_loosely_match
+dotnet_style_prefer_compound_assignment = true
+dotnet_style_prefer_conditional_expression_over_assignment = true
+dotnet_style_prefer_conditional_expression_over_return = true
+dotnet_style_prefer_foreach_explicit_cast_in_source = when_strongly_typed
+dotnet_style_prefer_inferred_anonymous_type_member_names = true
+dotnet_style_prefer_inferred_tuple_names = true
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true
+dotnet_style_prefer_simplified_boolean_expressions = true
+dotnet_style_prefer_simplified_interpolation = true
+
+# Field preferences
+dotnet_style_readonly_field = true
+
+# Parameter preferences
+dotnet_code_quality_unused_parameters = all
+
+# Suppression preferences
+dotnet_remove_unnecessary_suppression_exclusions = none
+
+# New line preferences
+dotnet_style_allow_multiple_blank_lines_experimental = true
+dotnet_style_allow_statement_immediately_after_block_experimental = true
+
+#### C# Coding Conventions ####
+
+# var preferences
+csharp_style_var_elsewhere = false
+csharp_style_var_for_built_in_types = false
+csharp_style_var_when_type_is_apparent = false
+
+# Expression-bodied members
+csharp_style_expression_bodied_accessors = true
+csharp_style_expression_bodied_constructors = false
+csharp_style_expression_bodied_indexers = true
+csharp_style_expression_bodied_lambdas = true
+csharp_style_expression_bodied_local_functions = false
+csharp_style_expression_bodied_methods = false
+csharp_style_expression_bodied_operators = false
+csharp_style_expression_bodied_properties = true
+
+# Pattern matching preferences
+csharp_style_pattern_matching_over_as_with_null_check = true
+csharp_style_pattern_matching_over_is_with_cast_check = true
+csharp_style_prefer_extended_property_pattern = true
+csharp_style_prefer_not_pattern = true
+csharp_style_prefer_pattern_matching = true
+csharp_style_prefer_switch_expression = true
+
+# Null-checking preferences
+csharp_style_conditional_delegate_call = true
+
+# Modifier preferences
+csharp_prefer_static_anonymous_function = true
+csharp_prefer_static_local_function = true
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async
+csharp_style_prefer_readonly_struct = true
+csharp_style_prefer_readonly_struct_member = true
+
+# Code-block preferences
+csharp_prefer_braces = true
+csharp_prefer_simple_using_statement = true
+csharp_prefer_system_threading_lock = true
+csharp_style_namespace_declarations = block_scoped
+csharp_style_prefer_method_group_conversion = true
+csharp_style_prefer_primary_constructors = true
+csharp_style_prefer_top_level_statements = true
+
+# Expression-level preferences
+csharp_prefer_simple_default_expression = true
+csharp_style_deconstructed_variable_declaration = true
+csharp_style_implicit_object_creation_when_type_is_apparent = true
+csharp_style_inlined_variable_declaration = true
+csharp_style_prefer_index_operator = true
+csharp_style_prefer_local_over_anonymous_function = true
+csharp_style_prefer_null_check_over_type_check = true
+csharp_style_prefer_range_operator = true
+csharp_style_prefer_tuple_swap = true
+csharp_style_prefer_utf8_string_literals = true
+csharp_style_throw_expression = true
+csharp_style_unused_value_assignment_preference = discard_variable
+csharp_style_unused_value_expression_statement_preference = discard_variable
+
+# 'using' directive preferences
+csharp_using_directive_placement = outside_namespace
+
+# New line preferences
+csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = true
+csharp_style_allow_blank_line_after_token_in_arrow_expression_clause_experimental = true
+csharp_style_allow_blank_line_after_token_in_conditional_expression_experimental = true
+csharp_style_allow_blank_lines_between_consecutive_braces_experimental = true
+csharp_style_allow_embedded_statements_on_same_line_experimental = true
+
+#### C# Formatting Rules ####
+
+# New line preferences
+csharp_new_line_before_catch = false
+csharp_new_line_before_else = false
+csharp_new_line_before_finally = false
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_open_brace = none
+csharp_new_line_between_query_expression_clauses = true
+
+# Indentation preferences
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_case_contents_when_block = true
+csharp_indent_labels = one_less_than_current
+csharp_indent_switch_labels = true
+
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_between_square_brackets = false
+
+# Wrapping preferences
+csharp_preserve_single_line_blocks = true
+csharp_preserve_single_line_statements = true
+
+#### Naming styles ####
+
+# Naming rules
+
+dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
+dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
+dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
+
+dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.types_should_be_pascal_case.symbols = types
+dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
+
+# Symbol specifications
+
+dotnet_naming_symbols.interface.applicable_kinds = interface
+dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interface.required_modifiers =
+
+dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
+dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types.required_modifiers =
+
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers =
+
+# Naming styles
+
+dotnet_naming_style.pascal_case.required_prefix =
+dotnet_naming_style.pascal_case.required_suffix =
+dotnet_naming_style.pascal_case.word_separator =
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+dotnet_naming_style.begins_with_i.required_prefix = I
+dotnet_naming_style.begins_with_i.required_suffix =
+dotnet_naming_style.begins_with_i.word_separator =
+dotnet_naming_style.begins_with_i.capitalization = pascal_case

--- a/Build/Manage-Module.ps1
+++ b/Build/Manage-Module.ps1
@@ -115,7 +115,7 @@ Build-Module -ModuleName 'PSEventViewer' {
         ResolveBinaryConflictsName        = 'PSEventViewer'
         NETProjectName                    = 'PSEventViewer'
         NETConfiguration                  = 'Release'
-        NETFramework                      = 'net6.0', 'net472'
+        NETFramework                      = 'net8.0', 'net472'
         NETSearchClass                    = "PSEventViewer.CmdletFindEvent"
         NETHandleAssemblyWithSameName     = $true
         #NETMergeLibraryDebugging          = $true

--- a/Examples/Example.QueryNamedEventsSMB01.ps1
+++ b/Examples/Example.QueryNamedEventsSMB01.ps1
@@ -1,0 +1,10 @@
+﻿Clear-Host
+Import-Module $PSScriptRoot\..\PSEventViewer.psd1 -Force
+
+$findWinEventSplat = @{
+    Type        = 'ADSMBServerAuditV1'
+    MachineName = 'AD1', 'AD2', 'AD0'
+    Verbose     = $true
+}
+
+Find-WinEvent @findWinEventSplat -TimePeriod Last3Days

--- a/PSEventViewer.psd1
+++ b/PSEventViewer.psd1
@@ -8,7 +8,7 @@
     Description          = 'Simple module allowing parsing of event logs. Has its own quirks...'
     FunctionsToExport    = @('Get-Events', 'Get-EventsFilter', 'Get-EventsInformation', 'Get-EventsSettings', 'Set-EventsSettings')
     GUID                 = '5df72a79-cdf6-4add-b38d-bcacf26fb7bc'
-    ModuleVersion        = '2.1.0'
+    ModuleVersion        = '2.2.0'
     PowerShellVersion    = '5.1'
     PrivateData          = @{
         PSData = @{
@@ -21,7 +21,7 @@
     RequiredModules      = @(@{
             Guid          = 'ee272aa8-baaa-4edf-9f45-b6d6f7d844fe'
             ModuleName    = 'PSSharedGoods'
-            ModuleVersion = '0.0.295'
+            ModuleVersion = '0.0.300'
         }, 'Microsoft.PowerShell.Utility', 'Microsoft.PowerShell.Management', 'Microsoft.PowerShell.Diagnostics')
     RootModule           = 'PSEventViewer.psm1'
 }

--- a/Sources/EventViewerX/Rules/ActiveDirectory/SMB.cs
+++ b/Sources/EventViewerX/Rules/ActiveDirectory/SMB.cs
@@ -1,0 +1,33 @@
+﻿
+using System;
+
+namespace EventViewerX.Rules.ActiveDirectory {
+    /// <summary>
+    /// SMB Server Audit
+    /// 3000: SMB1 access
+    ///
+    /// Before running the script, you need to enable the audit policy on the server.
+    /// Set-SmbServerConfiguration -AuditSmb1Access $true
+    ///
+    /// Alternatively via registry:
+    /// HKLM\SYSTEM\CurrentControlSet\Services\LanmanServer\Parameters
+    /// AuditSmb1Access => REG_DWORD => 1
+    /// </summary>
+    public class SMBServerAudit : EventObjectSlim {
+        public string Computer;
+        public string Action;
+        public string ClientName;
+        public string ClientAddress;
+        public DateTime When;
+
+        public SMBServerAudit(EventObject eventObject) : base(eventObject) {
+            _eventObject = eventObject;
+            Type = "ADSMBServerAuditV1";
+
+            Computer = _eventObject.ComputerName;
+            Action = _eventObject.MessageSubject;
+            ClientAddress = _eventObject.GetValueFromDataDictionary("Client Address");
+            When = _eventObject.TimeCreated;
+        }
+    }
+}

--- a/Sources/EventViewerX/SearchEvents.NamedEventsDetails.cs
+++ b/Sources/EventViewerX/SearchEvents.NamedEventsDetails.cs
@@ -40,6 +40,8 @@ namespace EventViewerX {
         OSCrash,
         OSStartupShutdownCrash,
         OSTimeChange,
+
+        ADSMBServerAuditV1,
     }
 
     public partial class SearchEvents : Settings {
@@ -71,6 +73,8 @@ namespace EventViewerX {
             // ldap events
             { NamedEvents.ADLdapBindingSummary, (new List<int> { 2887 }, "Directory Service") },
             { NamedEvents.ADLdapBindingDetails,(new List<int> { 2889 }, "Directory Service") },
+            // samba
+            { NamedEvents.ADSMBServerAuditV1, (new List<int> { 3000 }, "Microsoft-Windows-SMBServer/Audit") },
             // logs cleared
             { NamedEvents.LogsClearedSecurity, (new List<int> { 1102,1105 }, "Security") },
             { NamedEvents.LogsClearedOther,(new List<int> { 104 }, "System") },
@@ -179,6 +183,8 @@ namespace EventViewerX {
                             return new OSStartupShutdownCrash(eventObject);
                         case NamedEvents.OSTimeChange:
                             return new OSTimeChange(eventObject);
+                        case NamedEvents.ADSMBServerAuditV1:
+                            return new SMBServerAudit(eventObject);
                         default:
                             throw new ArgumentException($"You forgot to add NamedEvents value properly: {typeEvents}");
                     }


### PR DESCRIPTION
This pull request includes several changes to improve the configuration and functionality of the `PSEventViewer` module. The most important changes include updates to the `.editorconfig` file to enforce coding conventions, upgrading the .NET framework version, adding a new example script, and enhancing the event processing capabilities.

**Configuration and Conventions:**

* [`.editorconfig`](diffhunk://#diff-0947e2727d6bad8cd0ac4122f5314bb5b04e337393075bc4b5ef143b17fcbd5bR1-R244): Added configuration settings to enforce coding conventions for C# files, including indentation, new line preferences, and naming styles.

**Framework and Module Updates:**

* [`Build/Manage-Module.ps1`](diffhunk://#diff-7461acf56e51fc170dfae6bc9dfc1720f7450f74c3870431ea44a55b04213d45L118-R118): Updated the .NET framework version from `net6.0` to `net8.0` for the `PSEventViewer` module.
* [`PSEventViewer.psd1`](diffhunk://#diff-601039d9829182f9498040626a4e03fb4d4a54683afbd325167aaed31f6e085cL11-R11): Updated the module version to `2.2.0` and the required module `PSSharedGoods` to version `0.0.300`. [[1]](diffhunk://#diff-601039d9829182f9498040626a4e03fb4d4a54683afbd325167aaed31f6e085cL11-R11) [[2]](diffhunk://#diff-601039d9829182f9498040626a4e03fb4d4a54683afbd325167aaed31f6e085cL24-R24)

**New Features and Enhancements:**

* [`Examples/Example.QueryNamedEventsSMB01.ps1`](diffhunk://#diff-a835bee3b336a47a60b5bb26514461af9ae4e1c77fc8f39d293f2132cfa9f461R1-R10): Added a new example script for querying named events related to SMB server audit.
* [`Sources/EventViewerX/Rules/ActiveDirectory/SMB.cs`](diffhunk://#diff-96ffe0ad02da153f7768a4ded69b6304b5d5b48a6151e8330b910a110a0c5fd1R1-R33): Introduced a new class `SMBServerAudit` for processing SMB server audit events.
* [`Sources/EventViewerX/SearchEvents.NamedEventsDetails.cs`](diffhunk://#diff-0a2cd0f96b3a92d4a0b64f9f834bb391e181716038726c8c5a2b603bd4d73f73R43-R44): Added support for the new named event `ADSMBServerAuditV1` in the `SearchEvents` class. [[1]](diffhunk://#diff-0a2cd0f96b3a92d4a0b64f9f834bb391e181716038726c8c5a2b603bd4d73f73R43-R44) [[2]](diffhunk://#diff-0a2cd0f96b3a92d4a0b64f9f834bb391e181716038726c8c5a2b603bd4d73f73R76-R77) [[3]](diffhunk://#diff-0a2cd0f96b3a92d4a0b64f9f834bb391e181716038726c8c5a2b603bd4d73f73R186-R187)