### PR TITLE
Allow null ComputerName

### DIFF
--- a/Sources/EventViewerX.Tests/EventViewerX.Tests.csproj
+++ b/Sources/EventViewerX.Tests/EventViewerX.Tests.csproj
@@ -27,6 +27,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\EventViewerX\EventViewerX.csproj" />
+        <ProjectReference Include="..\PSEventViewer\PSEventViewer.csproj" />
     </ItemGroup>
 
 </Project>

--- a/Sources/EventViewerX.Tests/TestWriteWinEvent.cs
+++ b/Sources/EventViewerX.Tests/TestWriteWinEvent.cs
@@ -1,0 +1,27 @@
+using System.Diagnostics;
+using System.Linq;
+using Xunit;
+
+namespace EventViewerX.Tests {
+    public class TestWriteWinEvent {
+        [Fact]
+        public void MachineNameParameterAllowsNull() {
+            var field = typeof(PSEventViewer.CmdletWriteWinEvent).GetField("MachineName");
+            Assert.NotNull(field);
+            var hasAllowNull = field.CustomAttributes.Any(a => a.AttributeType.Name == "AllowNullAttribute");
+            Assert.True(hasAllowNull);
+        }
+
+        [Fact]
+        public void WriteEventDoesNotThrowWhenMachineIsNull() {
+            if (!OperatingSystem.IsWindows()) return;
+            SearchEvents.WriteEvent(
+                "Windows PowerShell",
+                "Application",
+                "Codex test message",
+                EventLogEntryType.Information,
+                1,
+                null!);
+        }
+    }
+}

--- a/Sources/PSEventViewer/CmdletWriteWinEvent.cs
+++ b/Sources/PSEventViewer/CmdletWriteWinEvent.cs
@@ -5,6 +5,10 @@
 public sealed class CmdletWriteWinEvent : AsyncPSCmdlet {
     [Alias("ComputerName", "ServerName")]
     [Parameter(Mandatory = false, ParameterSetName = "GenericEvents")]
+    [AllowNull]
+    [AllowEmptyString]
+    // When not provided or empty, events are written to the local machine.
+    // SearchEvents.WriteEvent and CreateLogSource handle null/empty strings.
     public string MachineName;
 
     [Parameter(Mandatory = true, Position = 0, ParameterSetName = "RecordId")]

--- a/Tests/Write-WinEvent.Tests.ps1
+++ b/Tests/Write-WinEvent.Tests.ps1
@@ -1,0 +1,18 @@
+Describe 'Write-WinEvent cmdlet' {
+    BeforeAll {
+        Import-Module -Force $PSScriptRoot/..\PSEventViewer.psd1
+    }
+
+    It 'exports Write-Event alias' {
+        (Get-Alias Write-Event).Definition | Should -Be 'Write-WinEvent'
+    }
+
+    It 'allows null ComputerName parameter' {
+        if (-not $IsWindows) {
+            return
+        }
+        $err = $null
+        Write-Event -LogName 'Application' -Source 'Windows PowerShell' -ID 1 -Message 'Codex test message' -Computer $null -ErrorAction SilentlyContinue -ErrorVariable err
+        $err | Should -BeNullOrEmpty
+    }
+}


### PR DESCRIPTION
## Summary
- allow null or empty ComputerName in `CmdletWriteWinEvent`

## Testing
- `dotnet test Sources/EventViewerX.sln -c Release`


------
https://chatgpt.com/codex/tasks/task_e_684d2ac19544832e9bdd3b127da62ae6