### PR TITLE
Fix file path for QueryFileInformation test

### DIFF
--- a/Sources/EventViewerX.Tests/TestEventInformation.cs
+++ b/Sources/EventViewerX.Tests/TestEventInformation.cs
@@ -18,7 +18,7 @@ namespace EventViewerX.Tests {
         [Fact]
         public void QueryFileInformation() {
             if (!OperatingSystem.IsWindows()) return;
-            var path = Path.Combine("..", "..", "..", "..", "Tests", "Logs", "Active Directory Web Services.evtx");
+            var path = Path.Combine("..", "..", "..", "..", "..", "Tests", "Logs", "Active Directory Web Services.evtx");
             var result = SearchEvents.GetWinEventInformation(null, null, new List<string> { path }, 1).ToList();
             Assert.Single(result);
             Assert.Equal("File", result[0].Source);


### PR DESCRIPTION
## Summary
- fix relative path in `TestEventInformation` to correctly locate log file

## Testing
- `dotnet test Sources/EventViewerX.sln --configuration Debug --verbosity normal --logger trx --collect:"XPlat Code Coverage"`
- `dotnet build Sources/EventViewerX.sln -c Release`


------
https://chatgpt.com/codex/tasks/task_e_685e89df0c90832ea1f6fb3f95202b0f