### PR TITLE
Fix message parsing for Windows newlines

### DIFF
--- a/Sources/EventViewerX/EventObject.cs
+++ b/Sources/EventViewerX/EventObject.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.Eventing.Reader;
 using System.Linq;
 using System.Security.Principal;
 using System.Xml.Linq;
+using System.Text.RegularExpressions;
 
 namespace EventViewerX {
     public class EventObject {
@@ -166,7 +167,7 @@ namespace EventViewerX {
             Dictionary<string, string> data = new Dictionary<string, string>();
 
             // Split the message into lines
-            string[] lines = message.Split('\n');
+            string[] lines = Regex.Split(message, "\r?\n");
 
             // Find the first non-empty line and add it to the dictionary with a default key of "Message"
             string firstLine = lines.FirstOrDefault(line => !string.IsNullOrWhiteSpace(line));


### PR DESCRIPTION
## Summary
- parse messages with `\r?\n` so Windows line endings are handled

## Testing
- `dotnet restore Sources/EventViewerX/EventViewerX.csproj`
- `dotnet build Sources/EventViewerX/EventViewerX.csproj --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_685fa7ea1880832eabda86e82dca16f2