### PR TITLE
Handle EventObject XML parsing errors

### DIFF
--- a/Sources/EventViewerX/EventObject.cs
+++ b/Sources/EventViewerX/EventObject.cs
@@ -208,7 +208,13 @@ namespace EventViewerX {
             Dictionary<string, string> data = new Dictionary<string, string>();
 
             // Parse the XML data into an XElement
-            XElement root = XElement.Parse(xmlData);
+            XElement root;
+            try {
+                root = XElement.Parse(xmlData);
+            } catch (Exception ex) {
+                Settings._logger.WriteWarning($"Failed to parse event XML. Error: {ex.Message}");
+                return data;
+            }
 
             // Get the namespace of the root element
             XNamespace ns = root.GetDefaultNamespace();


### PR DESCRIPTION
## Summary
- improve ParseXML error handling in `EventObject`

## Testing
- `dotnet build Sources/EventViewerX/EventViewerX.csproj -c Release`
- `pwsh -NoLogo -NoProfile -Command ./PSEventViewer.Tests.ps1` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_685fa8037b1c832ea45c549c1d9fe5d5