### PR TITLE
Optimize UAC translation

### DIFF
--- a/Sources/EventViewerX/EventObjectSlim.cs
+++ b/Sources/EventViewerX/EventObjectSlim.cs
@@ -8,6 +8,31 @@ public class EventObjectSlim {
     public string GatheredLogName; // = _eventObject.LogName;
     public string Type;
 
+    private static readonly Dictionary<int, string> uacFlags = new Dictionary<int, string> {
+        { 0x0001, "SCRIPT" },
+        { 0x0002, "ACCOUNTDISABLE" },
+        { 0x0008, "HOMEDIR_REQUIRED" },
+        { 0x0010, "LOCKOUT" },
+        { 0x0020, "PASSWD_NOTREQD" },
+        { 0x0040, "PASSWD_CANT_CHANGE" },
+        { 0x0080, "ENCRYPTED_TEXT_PWD_ALLOWED" },
+        { 0x0100, "TEMP_DUPLICATE_ACCOUNT" },
+        { 0x0200, "NORMAL_ACCOUNT" },
+        { 0x0800, "INTERDOMAIN_TRUST_ACCOUNT" },
+        { 0x1000, "WORKSTATION_TRUST_ACCOUNT" },
+        { 0x2000, "SERVER_TRUST_ACCOUNT" },
+        { 0x10000, "DONT_EXPIRE_PASSWORD" },
+        { 0x20000, "MNS_LOGON_ACCOUNT" },
+        { 0x40000, "SMARTCARD_REQUIRED" },
+        { 0x80000, "TRUSTED_FOR_DELEGATION" },
+        { 0x100000, "NOT_DELEGATED" },
+        { 0x200000, "USE_DES_KEY_ONLY" },
+        { 0x400000, "DONT_REQ_PREAUTH" },
+        { 0x800000, "PASSWORD_EXPIRED" },
+        { 0x1000000, "TRUSTED_TO_AUTH_FOR_DELEGATION" },
+        { 0x04000000, "PARTIAL_SECRETS_ACCOUNT" }
+    };
+
 
     public EventObjectSlim(EventObject eventObject) {
         _eventObject = eventObject;
@@ -69,31 +94,7 @@ public class EventObjectSlim {
         // Convert the hexadecimal value to an integer
         int uacValue = int.Parse(hexValue, System.Globalization.NumberStyles.HexNumber);
 
-        // Define the UAC flags
-        Dictionary<int, string> uacFlags = new Dictionary<int, string> {
-                { 0x0001, "SCRIPT" },
-                { 0x0002, "ACCOUNTDISABLE" },
-                { 0x0008, "HOMEDIR_REQUIRED" },
-                { 0x0010, "LOCKOUT" },
-                { 0x0020, "PASSWD_NOTREQD" },
-                { 0x0040, "PASSWD_CANT_CHANGE" },
-                { 0x0080, "ENCRYPTED_TEXT_PWD_ALLOWED" },
-                { 0x0100, "TEMP_DUPLICATE_ACCOUNT" },
-                { 0x0200, "NORMAL_ACCOUNT" },
-                { 0x0800, "INTERDOMAIN_TRUST_ACCOUNT" },
-                { 0x1000, "WORKSTATION_TRUST_ACCOUNT" },
-                { 0x2000, "SERVER_TRUST_ACCOUNT" },
-                { 0x10000, "DONT_EXPIRE_PASSWORD" },
-                { 0x20000, "MNS_LOGON_ACCOUNT" },
-                { 0x40000, "SMARTCARD_REQUIRED" },
-                { 0x80000, "TRUSTED_FOR_DELEGATION" },
-                { 0x100000, "NOT_DELEGATED" },
-                { 0x200000, "USE_DES_KEY_ONLY" },
-                { 0x400000, "DONT_REQ_PREAUTH" },
-                { 0x800000, "PASSWORD_EXPIRED" },
-                { 0x1000000, "TRUSTED_TO_AUTH_FOR_DELEGATION" },
-                { 0x04000000, "PARTIAL_SECRETS_ACCOUNT" }
-            };
+        // Use predefined UAC flags dictionary
 
         // Map each bit in the UAC value to a UAC flag
         List<string> translatedFlags = new List<string>();

--- a/Sources/EventViewerX/EventObjectSlim.cs
+++ b/Sources/EventViewerX/EventObjectSlim.cs
@@ -31,7 +31,7 @@ public class EventObjectSlim {
         { 0x800000, "PASSWORD_EXPIRED" },
         { 0x1000000, "TRUSTED_TO_AUTH_FOR_DELEGATION" },
         { 0x04000000, "PARTIAL_SECRETS_ACCOUNT" }
-    }
+    };
   
     private static readonly Dictionary<string, string> OperationTypeLookup = new()
     {


### PR DESCRIPTION
## Summary
- add a static cache for UAC flag mapping so it isn't recreated each call

## Testing
- `dotnet build Sources/EventViewerX.sln -c Release`
- `pwsh -NoLogo -NoProfile -Command ./PSEventViewer.Tests.ps1` *(fails: Write-Color/Invoke-Pester not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fa8b7e4c0832eadd10e8410a8babd