### PR TITLE
Handle FQDN lookup errors

### DIFF
--- a/Sources/EventViewerX/SearchEvents.QueryLog.cs
+++ b/Sources/EventViewerX/SearchEvents.QueryLog.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics.Eventing.Reader;
 using System.IO;
+using System.Net;
 
 namespace EventViewerX;
 
@@ -40,7 +41,12 @@ public partial class SearchEvents : Settings {
     /// </summary>
     /// <returns></returns>
     private static string GetFQDN() {
-        return Dns.GetHostEntry("").HostName;
+        try {
+            return Dns.GetHostEntry("").HostName;
+        } catch (Exception ex) {
+            _logger.WriteVerbose($"Failed to resolve FQDN via DNS: {ex.Message}. Falling back to machine name.");
+            return Environment.MachineName;
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- guard FQDN retrieval with try/catch
- fall back to `Environment.MachineName` when DNS lookup fails

## Testing
- `dotnet build Sources/EventViewerX/EventViewerX.csproj --no-restore`
- `dotnet build Sources/EventViewerX.Tests/EventViewerX.Tests.csproj --no-restore`
- `dotnet test Sources/EventViewerX.Tests/EventViewerX.Tests.csproj --no-build`


------
https://chatgpt.com/codex/tasks/task_e_685fa7facbb4832e9b193fc8e5c224e3