### PR TITLE
Add NTLMv1 event tracking

### DIFF
--- a/Sources/EventViewerX/Rules/ActiveDirectory/Users/ADUserLogonNTLMv1.cs
+++ b/Sources/EventViewerX/Rules/ActiveDirectory/Users/ADUserLogonNTLMv1.cs
@@ -1,0 +1,22 @@
+namespace EventViewerX.Rules.ActiveDirectory;
+
+/// <summary>
+/// Active Directory User Logon NTLMv1
+/// 4624: An account was successfully logged on (NTLMv1)
+/// </summary>
+public class ADUserLogonNTLMv1 : ADUserLogon {
+    public string LmPackageName;
+    public string PackageName;
+    public string KeyLength;
+    public string ProcessId;
+    public string ProcessName;
+
+    public ADUserLogonNTLMv1(EventObject eventObject) : base(eventObject) {
+        Type = "ADUserLogonNTLMv1";
+        LmPackageName = _eventObject.GetValueFromDataDictionary("LmPackageName");
+        PackageName = _eventObject.GetValueFromDataDictionary("AuthenticationPackageName");
+        KeyLength = _eventObject.GetValueFromDataDictionary("KeyLength");
+        ProcessId = _eventObject.GetValueFromDataDictionary("ProcessId");
+        ProcessName = _eventObject.GetValueFromDataDictionary("ProcessName");
+    }
+}

--- a/Sources/EventViewerX/SearchEvents.NamedEventsDetails.cs
+++ b/Sources/EventViewerX/SearchEvents.NamedEventsDetails.cs
@@ -30,6 +30,7 @@ namespace EventViewerX {
         ADUserChangeDetailed,
         ADUserLockouts,
         ADUserLogon,
+        ADUserLogonNTLMv1,
         ADUserLogonKerberos,
         ADUserLogonFailed,
         ADUserUnlocked,
@@ -75,6 +76,7 @@ namespace EventViewerX {
             { NamedEvents.ADOrganizationalUnitChangeDetailed, ([5136, 5137, 5139, 5141], "Security") },
             { NamedEvents.ADUserLockouts, ([4740], "Security") },
             { NamedEvents.ADUserLogon, ([4624], "Security") },
+            { NamedEvents.ADUserLogonNTLMv1, ([4624], "Security") },
             { NamedEvents.ADUserLogonFailed, ([4625], "Security")},
             { NamedEvents.ADUserLogonKerberos, ([4768], "Security") },
             { NamedEvents.ADUserUnlocked, ([4767], "Security") },
@@ -161,6 +163,11 @@ namespace EventViewerX {
                             return new ADUserLockouts(eventObject);
                         case NamedEvents.ADUserLogon:
                             return new ADUserLogon(eventObject);
+                        case NamedEvents.ADUserLogonNTLMv1:
+                            if (eventObject.ValueMatches("LmPackageName", "NTLM V1")) {
+                                return new ADUserLogonNTLMv1(eventObject);
+                            }
+                            break;
                         case NamedEvents.ADUserLogonKerberos:
                             return new ADUserLogonKerberos(eventObject);
                         case NamedEvents.ADUserLogonFailed:


### PR DESCRIPTION
## Summary
- add new rule `ADUserLogonNTLMv1` for EventID 4624 when `LmPackageName` shows NTLMv1
- register new `NamedEvents.ADUserLogonNTLMv1`
- handle the new case when building NamedEvents

## Testing
- `dotnet restore Sources/EventViewerX.sln`
- `dotnet build Sources/EventViewerX.sln --configuration Debug --no-restore`
- `dotnet test Sources/EventViewerX.sln --no-build --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_685faad0cc70832e84f06f11cb9c86ed