### PR TITLE
Add scriptblock callback support to WatchEvents

### DIFF
--- a/Sources/EventViewerX.Examples/Examples.EventWatchingBasic.cs
+++ b/Sources/EventViewerX.Examples/Examples.EventWatchingBasic.cs
@@ -6,7 +6,7 @@
                 Warning = true,
                 Verbose = true
             };
-            c1.Watch("AD1", "Security", new List<int>() { 4627, 4624 });
+            c1.Watch("AD1", "Security", new List<int>() { 4627, 4624 }, e => Console.WriteLine($"Found event {e.Id}"));
         }
     }
 }

--- a/Sources/PSEventViewer/CmdletStartEVXWatcher.cs
+++ b/Sources/PSEventViewer/CmdletStartEVXWatcher.cs
@@ -1,6 +1,7 @@
 ﻿using EventViewerX;
 using System.Management.Automation;
 using System.Threading.Tasks;
+using System.Linq;
 
 namespace PSEventViewer {
     /// <summary>
@@ -13,7 +14,20 @@ namespace PSEventViewer {
     public sealed class CmdletStartEVXWatcher : AsyncPSCmdlet {
         private WatchEvents EventWatching { get; set; }
 
-        [Parameter(Mandatory = false, Position = 1)] public int NumberOfThreads { get; set; } = 8;
+        [Parameter(Mandatory = true, Position = 0)]
+        public string MachineName { get; set; }
+
+        [Parameter(Mandatory = true, Position = 1)]
+        public string LogName { get; set; }
+
+        [Parameter(Mandatory = true, Position = 2)]
+        public int[] EventId { get; set; }
+
+        [Parameter(Mandatory = true, Position = 3)]
+        public ScriptBlock Action { get; set; }
+
+        [Parameter(Mandatory = false)]
+        public int NumberOfThreads { get; set; } = 8;
 
         protected override Task BeginProcessingAsync() {
             // Initialize the logger to be able to see verbose, warning, debug, error, progress, and information messages.
@@ -26,7 +40,7 @@ namespace PSEventViewer {
             return Task.CompletedTask;
         }
         protected override Task ProcessRecordAsync() {
-
+            EventWatching.Watch(MachineName, LogName, EventId.ToList(), e => Action.Invoke(e));
             return Task.CompletedTask;
         }
         protected override Task EndProcessingAsync() {


### PR DESCRIPTION
## Summary
- allow WatchEvents to invoke a callback when an event is detected
- wire up CmdletStartEVXWatcher to pass script blocks
- update watcher example with callback usage

## Testing
- `dotnet build Sources/EventViewerX/EventViewerX.csproj --no-restore`
- `dotnet build Sources/PSEventViewer/PSEventViewer.csproj --no-restore`
- `pwsh -NoLogo -NoProfile -Command Invoke-Pester -Path Tests -Passthru` *(fails: Invoke-Pester not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fadb14828832e8e15cd5698ee3f7d