### PR TITLE
Introduce KnownLog enum with QueryLog overloads

### DIFF
--- a/Sources/EventViewerX.Tests/TestSearchingEvents.cs
+++ b/Sources/EventViewerX.Tests/TestSearchingEvents.cs
@@ -1,4 +1,5 @@
 using Xunit;
+using EventViewerX;
 
 namespace EventViewerX.Tests {
     public class TestSearchingEvents {
@@ -6,7 +7,7 @@ namespace EventViewerX.Tests {
         public void QuerySecurityEvents4932and4933() {
             if (!OperatingSystem.IsWindows()) return;
             var fields = new List<string>() { "DestinationDRA", "SourceDRA", "NamingContext", "Options", "SessionID", "EndUSN", "StatusCode", "StartUSN" };
-            foreach (var eventObject in SearchEvents.QueryLog("Security", [4932, 4933], "AD1")) {
+            foreach (var eventObject in SearchEvents.QueryLog(KnownLog.Security, [4932, 4933], "AD1")) {
                 Assert.True(eventObject.Id == 4932 || eventObject.Id == 4933);
                 Assert.True(eventObject.Data.Count == 6 || eventObject.Data.Count == 7);
 
@@ -19,7 +20,7 @@ namespace EventViewerX.Tests {
         public void QuerySetupEventID2() {
             if (!OperatingSystem.IsWindows()) return;
             var fields = new List<string>() { "PackageIdentifier" };
-            foreach (var eventObject in SearchEvents.QueryLog("Setup", [2])) {
+            foreach (var eventObject in SearchEvents.QueryLog(KnownLog.Setup, [2])) {
                 Assert.True(eventObject.Id == 2);
                 Assert.True(eventObject.Data.Count == 5);
 
@@ -33,7 +34,7 @@ namespace EventViewerX.Tests {
         public void QuerySetupEventID1() {
             if (!OperatingSystem.IsWindows()) return;
             var fields = new List<string>() { "PackageIdentifier", "InitialPackageState" };
-            foreach (var eventObject in SearchEvents.QueryLog("Setup", [1])) {
+            foreach (var eventObject in SearchEvents.QueryLog(KnownLog.Setup, [1])) {
                 Assert.True(eventObject.Id == 1);
                 Assert.True(eventObject.Data.Count == 6);
 
@@ -47,7 +48,7 @@ namespace EventViewerX.Tests {
         public void QuerySystemEventID566() {
             if (!OperatingSystem.IsWindows()) return;
             var fields = new List<string>() { "BootId", "Reason", "MonitorReason" };
-            foreach (var eventObject in SearchEvents.QueryLog("System", [566])) {
+            foreach (var eventObject in SearchEvents.QueryLog(KnownLog.System, [566])) {
                 Assert.True(eventObject.Id == 566);
                 Assert.True(eventObject.Data.Count == 13);
 
@@ -62,7 +63,7 @@ namespace EventViewerX.Tests {
         public void QueryApplicationEvent10005() {
             if (!OperatingSystem.IsWindows()) return;
             var fields = new List<string>() { "RmSessionId", "nApplications", "RebootReasons", "Applications" };
-            foreach (var eventObject in SearchEvents.QueryLog("Application", [10005])) {
+            foreach (var eventObject in SearchEvents.QueryLog(KnownLog.Application, [10005])) {
                 Assert.True(eventObject.Id == 10005);
 
                 foreach (var field in fields) {
@@ -75,7 +76,7 @@ namespace EventViewerX.Tests {
         public void QueryApplicationEvent100() {
             if (!OperatingSystem.IsWindows()) return;
             var fields = new List<string>() { "NoNameA0" };
-            foreach (var eventObject in SearchEvents.QueryLog("Application", [100])) {
+            foreach (var eventObject in SearchEvents.QueryLog(KnownLog.Application, [100])) {
                 Assert.True(eventObject.Id == 100);
 
                 foreach (var field in fields) {

--- a/Sources/EventViewerX/Definitions/KnownLog.cs
+++ b/Sources/EventViewerX/Definitions/KnownLog.cs
@@ -1,0 +1,13 @@
+namespace EventViewerX;
+
+public enum KnownLog {
+    Application,
+    System,
+    Security,
+    Setup,
+    ForwardedEvents,
+    DirectoryService,
+    DNSServer,
+    WindowsPowerShell,
+    // Add other well-known logs as needed
+}

--- a/Sources/EventViewerX/SearchEvents.QueryLog.cs
+++ b/Sources/EventViewerX/SearchEvents.QueryLog.cs
@@ -202,7 +202,11 @@ public partial class SearchEvents : Settings {
                     // }
                 }
             }
-        }
+        } 
+    }
+
+    public static IEnumerable<EventObject> QueryLog(KnownLog logName, List<int> eventIds = null, string machineName = null, string providerName = null, Keywords? keywords = null, Level? level = null, DateTime? startTime = null, DateTime? endTime = null, string userId = null, int maxEvents = 0, List<long> eventRecordId = null, TimePeriod? timePeriod = null) {
+        return QueryLog(LogNameToString(logName), eventIds, machineName, providerName, keywords, level, startTime, endTime, userId, maxEvents, eventRecordId, timePeriod);
     }
 
     /// <summary>
@@ -312,6 +316,13 @@ public partial class SearchEvents : Settings {
         queryString.Append(condition);
     }
 
+    private static string LogNameToString(KnownLog logName) => logName switch {
+        KnownLog.DirectoryService => "Directory Service",
+        KnownLog.DNSServer => "DNS Server",
+        KnownLog.WindowsPowerShell => "Windows PowerShell",
+        _ => logName.ToString()
+    };
+
     public static IEnumerable<EventObject> QueryLogsParallel(string logName, List<int> eventIds = null, List<string> machineNames = null, string providerName = null, Keywords? keywords = null, Level? level = null, DateTime? startTime = null, DateTime? endTime = null, string userId = null, int maxEvents = 0, int maxThreads = 8, List<long> eventRecordId = null, TimePeriod? timePeriod = null) {
         if (machineNames == null || !machineNames.Any()) {
             machineNames = new List<string> { null };
@@ -356,6 +367,10 @@ public partial class SearchEvents : Settings {
         return results.GetConsumingEnumerable();
     }
 
+    public static IEnumerable<EventObject> QueryLogsParallel(KnownLog logName, List<int> eventIds = null, List<string> machineNames = null, string providerName = null, Keywords? keywords = null, Level? level = null, DateTime? startTime = null, DateTime? endTime = null, string userId = null, int maxEvents = 0, int maxThreads = 8, List<long> eventRecordId = null, TimePeriod? timePeriod = null) {
+        return QueryLogsParallel(LogNameToString(logName), eventIds, machineNames, providerName, keywords, level, startTime, endTime, userId, maxEvents, maxThreads, eventRecordId, timePeriod);
+    }
+
     private static Task CreateTask(string machineName, string logName, List<int> eventIds, string providerName, Keywords? keywords, Level? level, DateTime? startTime, DateTime? endTime, string userId, int maxEvents, SemaphoreSlim semaphore, BlockingCollection<EventObject> results, List<long> eventRecordId = null, TimePeriod? timePeriod = null) {
         return Task.Run(async () => {
             _logger.WriteVerbose($"Querying log on machine: {machineName}, logName: {logName}, event ids: " + string.Join(", ", eventIds ?? new List<int>()));
@@ -393,5 +408,9 @@ public partial class SearchEvents : Settings {
         });
 
         return results.GetConsumingEnumerable();
+    }
+
+    public static IEnumerable<EventObject> QueryLogsParallelForEach(KnownLog logName, List<int> eventIds = null, List<string> machineNames = null, string providerName = null, Keywords? keywords = null, Level? level = null, DateTime? startTime = null, DateTime? endTime = null, string userId = null, int maxEvents = 0, int maxThreads = 4, List<long> eventRecordId = null) {
+        return QueryLogsParallelForEach(LogNameToString(logName), eventIds, machineNames, providerName, keywords, level, startTime, endTime, userId, maxEvents, maxThreads, eventRecordId);
     }
 }


### PR DESCRIPTION
## Summary
- add a `KnownLog` enum for well-known logs
- overload log query methods to work with `KnownLog`
- update unit tests to use the new enum

## Testing
- `dotnet test Sources/EventViewerX.Tests/EventViewerX.Tests.csproj -c Release`
- `dotnet build Sources/EventViewerX.sln -c Release`


------
https://chatgpt.com/codex/tasks/task_e_685fadeda1bc832e8c3e2248d4861b1f