### PR TITLE
Fix DirectorySearcher disposal

### DIFF
--- a/Sources/EventViewerX/Helpers/ActiveDirectory/GroupPolicyHelpers.cs
+++ b/Sources/EventViewerX/Helpers/ActiveDirectory/GroupPolicyHelpers.cs
@@ -36,25 +36,26 @@ public class GroupPolicyHelpers {
     private static GroupPolicy QueryGroupPolicyInDomainByDistinguishedName(string domainName, string gpoDn) {
         try {
             using DirectoryEntry rootDSE = new DirectoryEntry($"LDAP://{domainName}/CN=Policies,CN=System,DC={domainName.Replace(".", ",DC=")}");
-            using DirectorySearcher searcher = new DirectorySearcher(rootDSE);
-            searcher.Filter = $"(&(objectClass=groupPolicyContainer)(distinguishedName={gpoDn}))";
-            searcher.PropertiesToLoad.Add("displayName");
-            searcher.PropertiesToLoad.Add("name");
-            searcher.PropertiesToLoad.Add("distinguishedName");
+            using (DirectorySearcher searcher = new DirectorySearcher(rootDSE)) {
+                searcher.Filter = $"(&(objectClass=groupPolicyContainer)(distinguishedName={gpoDn}))";
+                searcher.PropertiesToLoad.Add("displayName");
+                searcher.PropertiesToLoad.Add("name");
+                searcher.PropertiesToLoad.Add("distinguishedName");
 
-            SearchResult result = searcher.FindOne();
-            if (result != null) {
-                string gpoName = result.Properties["displayName"].Count > 0
-                    ? result.Properties["displayName"][0].ToString()
-                    : string.Empty;
-                string gpoId = result.Properties["name"].Count > 0
-                    ? result.Properties["name"][0].ToString()
-                    : string.Empty;
-                return new GroupPolicy {
-                    GpoName = gpoName,
-                    GpoId = gpoId,
-                    GpoDomain = domainName
-                };
+                SearchResult result = searcher.FindOne();
+                if (result != null) {
+                    string gpoName = result.Properties["displayName"].Count > 0
+                        ? result.Properties["displayName"][0].ToString()
+                        : string.Empty;
+                    string gpoId = result.Properties["name"].Count > 0
+                        ? result.Properties["name"][0].ToString()
+                        : string.Empty;
+                    return new GroupPolicy {
+                        GpoName = gpoName,
+                        GpoId = gpoId,
+                        GpoDomain = domainName
+                    };
+                }
             }
         } catch (Exception ex) {
             Console.WriteLine($"Error querying group policy by DN in domain {domainName}: {ex.Message}");


### PR DESCRIPTION
## Summary
- wrap DirectorySearcher usage in using block to ensure disposal

## Testing
- `dotnet build Sources/EventViewerX/EventViewerX.csproj -p:TargetFramework=net8.0 --no-restore`
- `dotnet test Sources/EventViewerX.Tests/EventViewerX.Tests.csproj -p:TargetFramework=net8.0`

------
https://chatgpt.com/codex/tasks/task_e_685fe0b59704832e88a85b5d4f1f1df6