### PR TITLE
Fix WriteEvent for null replacement strings

### DIFF
--- a/Sources/EventViewerX/SearchEvents.WriteEvent.cs
+++ b/Sources/EventViewerX/SearchEvents.WriteEvent.cs
@@ -63,7 +63,9 @@ public partial class SearchEvents : Settings {
                         LoggingMessages.Logger.WriteVerbose($"Writing event '{eventId}' of type '{type}' of category '{category}' to EventLog: '{message}'");
                         eventLog.WriteEntry(message, type, eventId, (short)category);
                     } else {
-                        var joinedMessage = replacementStrings.Prepend(message).ToArray();
+                        var joinedMessage = replacementStrings == null
+                            ? new[] { message }
+                            : replacementStrings.Prepend(message).ToArray();
                         // If rawData and/or replacementStrings are provided, write them to the event log.
                         LoggingMessages.Logger.WriteVerbose($"Writing event '{eventId}' of type '{type}' of category '{category}' to EventLog: '{joinedMessage}'");
                         eventLog.WriteEvent(eventInstance, rawData, joinedMessage);


### PR DESCRIPTION
## Summary
- prevent `WriteEvent` from failing when `replacementStrings` is null

## Testing
- `dotnet build Sources/EventViewerX/EventViewerX.csproj -c Release`
- `dotnet build Sources/PSEventViewer/PSEventViewer.csproj -c Release`
- `dotnet test Sources/EventViewerX.Tests/EventViewerX.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_685fe0c43ce8832ebde7be6ba0045c7d