### PR TITLE
Fix dictionary key lookups

### DIFF
--- a/Sources/EventViewerX/EventObjectSlim.cs
+++ b/Sources/EventViewerX/EventObjectSlim.cs
@@ -50,20 +50,21 @@ public class EventObjectSlim {
     }
 
     internal static string ConvertToObjectAffected(EventObject eventObject) {
-        if (eventObject.Data.ContainsKey("TargetUserName") && eventObject.Data.ContainsKey("TargetDomainName")) {
-            return eventObject.Data["TargetDomainName"] + "\\" + eventObject.Data["TargetUserName"];
-        } else if (eventObject.Data.ContainsKey("TargetUserName")) {
-            return eventObject.Data["TargetUserName"];
-        } else {
-            return "";
+        if (eventObject.Data.TryGetValue("TargetUserName", out var targetUserName)) {
+            if (eventObject.Data.TryGetValue("TargetDomainName", out var targetDomainName)) {
+                return targetDomainName + "\\" + targetUserName;
+            }
+
+            return targetUserName;
         }
+
+        return string.Empty;
     }
+
     internal static string ConvertToSamAccountName(EventObject eventObject) {
-        if (eventObject.Data.ContainsKey("SamAccountName")) {
-            return eventObject.Data["SamAccountName"];
-        } else {
-            return "";
-        }
+        return eventObject.Data.TryGetValue("SamAccountName", out var samAccountName)
+            ? samAccountName
+            : string.Empty;
     }
     internal string ConvertFromOperationType(string s) {
         if (OperationTypeLookup.ContainsKey(s)) {


### PR DESCRIPTION
## Summary
- use `TryGetValue` for dictionary access in `EventObjectSlim`

## Testing
- `dotnet build Sources/EventViewerX/EventViewerX.csproj -c Release`
- `pwsh -NoLogo -NoProfile -Command ./PSEventViewer.Tests.ps1` *(fails: Write-Color not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fe0cb4a88832ea0d548ab1e163a91