### PR TITLE
Implement Get-EVXProviderList cmdlet

### DIFF
--- a/PSEventViewer.psd1
+++ b/PSEventViewer.psd1
@@ -1,7 +1,7 @@
 ﻿@{
-    AliasesToExport      = @('Get-EventViewerXEvent', 'Find-WinEvent', 'Get-Events', 'Get-EventViewerXFilter', 'Get-WinEventFilter', 'Get-EventsFilter', 'Set-EventViewerXInfo', 'Set-EventsInformation', 'Set-EventsSettings', 'Start-EventViewerXWatcher', 'Start-EventWatching', 'Get-EventViewerXInfo', 'Get-EventsSettings', 'Get-EventsInformation', 'Write-EventViewerXEntry', 'Write-WinEvent')
+    AliasesToExport      = @('Get-EventViewerXEvent', 'Find-WinEvent', 'Get-Events', 'Get-EventViewerXFilter', 'Get-WinEventFilter', 'Get-EventsFilter', 'Set-EventViewerXInfo', 'Set-EventsInformation', 'Set-EventsSettings', 'Start-EventViewerXWatcher', 'Start-EventWatching', 'Get-EventViewerXInfo', 'Get-EventsSettings', 'Get-EventsInformation', 'Write-EventViewerXEntry', 'Write-WinEvent', 'Get-EventViewerXProviderList')
     Author               = 'Przemyslaw Klys'
-    CmdletsToExport      = @('Get-EVXEvent', 'Get-EVXFilter', 'Set-EVXInfo', 'Start-EVXWatcher', 'Get-EVXInfo', 'Write-EVXEntry')
+    CmdletsToExport      = @('Get-EVXEvent', 'Get-EVXFilter', 'Set-EVXInfo', 'Start-EVXWatcher', 'Get-EVXInfo', 'Write-EVXEntry', 'Get-EVXProviderList')
     CompanyName          = 'Evotec'
     CompatiblePSEditions = @('Desktop', 'Core')
     Copyright            = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'

--- a/PSEventViewer.psd1
+++ b/PSEventViewer.psd1
@@ -1,7 +1,7 @@
 ﻿@{
-    AliasesToExport      = @('Get-EventViewerXEvent', 'Find-WinEvent', 'Get-Events', 'Get-EventViewerXFilter', 'Get-WinEventFilter', 'Get-EventsFilter', 'Set-EventViewerXInfo', 'Set-EventsInformation', 'Set-EventsSettings', 'Start-EventViewerXWatcher', 'Start-EventWatching', 'Get-EventViewerXInfo', 'Get-EventsSettings', 'Get-EventsInformation', 'Write-EventViewerXEntry', 'Write-WinEvent', 'Get-EventViewerXProviderList')
+    AliasesToExport      = @('Get-EventViewerXEvent', 'Find-WinEvent', 'Get-Events', 'Get-EventViewerXFilter', 'Get-WinEventFilter', 'Get-EventsFilter', 'Get-EventViewerXInfo', 'Get-EventsSettings', 'Get-EventsInformation', 'Get-EventViewerXProviderList', 'Remove-EventViewerXSource', 'Remove-WinEventSource', 'Set-EventViewerXInfo', 'Set-EventsInformation', 'Set-EventsSettings', 'Start-EventViewerXWatcher', 'Start-EventWatching', 'Write-EventViewerXEntry', 'Write-WinEvent')
     Author               = 'Przemyslaw Klys'
-    CmdletsToExport      = @('Get-EVXEvent', 'Get-EVXFilter', 'Set-EVXInfo', 'Start-EVXWatcher', 'Get-EVXInfo', 'Write-EVXEntry', 'Get-EVXProviderList')
+    CmdletsToExport      = @('Get-EVXEvent', 'Get-EVXFilter', 'Get-EVXInfo', 'Get-EVXProviderList', 'Remove-EVXSource', 'Set-EVXInfo', 'Start-EVXWatcher', 'Write-EVXEntry')
     CompanyName          = 'Evotec'
     CompatiblePSEditions = @('Desktop', 'Core')
     Copyright            = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'

--- a/Sources/PSEventViewer/CmdletGetEVXProviderList.cs
+++ b/Sources/PSEventViewer/CmdletGetEVXProviderList.cs
@@ -1,0 +1,24 @@
+using System.Diagnostics.Eventing.Reader;
+using System.Management.Automation;
+using System.Threading.Tasks;
+
+namespace PSEventViewer;
+
+/// <summary>
+/// Returns a list of available Windows event log providers.
+/// </summary>
+[Cmdlet(VerbsCommon.Get, "EVXProviderList")]
+[Alias("Get-EventViewerXProviderList")]
+[OutputType(typeof(string))]
+public sealed class CmdletGetEVXProviderList : AsyncPSCmdlet
+{
+    protected override Task ProcessRecordAsync()
+    {
+        using EventLogSession session = new();
+        foreach (string provider in session.GetProviderNames())
+        {
+            WriteObject(provider);
+        }
+        return Task.CompletedTask;
+    }
+}

--- a/Tests/Get-EVXProviderList.Tests.ps1
+++ b/Tests/Get-EVXProviderList.Tests.ps1
@@ -1,0 +1,6 @@
+Describe 'Get-EVXProviderList' {
+    It 'Should return provider names' {
+        $providers = Get-EVXProviderList
+        $providers | Should -Not -BeNullOrEmpty
+    }
+}


### PR DESCRIPTION
## Summary
- add `Get-EVXProviderList` cmdlet that lists available event log providers
- expose the new cmdlet and alias in module manifest
- test that `Get-EVXProviderList` returns provider names

## Testing
- `dotnet build Sources/EventViewerX.sln -c Release`
- `pwsh -NoLogo -NoProfile -Command ./PSEventViewer.Tests.ps1` *(fails: required modules missing)*

------
https://chatgpt.com/codex/tasks/task_e_685fe0fe61f4832e861668c05111849a