### PR TITLE
Add dedicated Group Policy event classes

### DIFF
--- a/Sources/EventViewerX/Rules/ActiveDirectory/GroupPolicies/GpoCreated.cs
+++ b/Sources/EventViewerX/Rules/ActiveDirectory/GroupPolicies/GpoCreated.cs
@@ -1,0 +1,20 @@
+namespace EventViewerX.Rules.ActiveDirectory;
+
+public class GpoCreated : EventObjectSlim {
+    public string Computer;
+    public string Action;
+    public string GpoName;
+    public string Who;
+    public DateTime When;
+
+    public GpoCreated(EventObject eventObject) : base(eventObject) {
+        _eventObject = eventObject;
+        Type = "GpoCreated";
+        Computer = _eventObject.ComputerName;
+        Action = _eventObject.MessageSubject;
+        GpoName = _eventObject.GetValueFromDataDictionary("ObjectDN");
+        Who = _eventObject.GetValueFromDataDictionary("SubjectUserName", "SubjectDomainName", "\\", reverseOrder: true);
+        When = _eventObject.TimeCreated;
+    }
+}
+

--- a/Sources/EventViewerX/Rules/ActiveDirectory/GroupPolicies/GpoDeleted.cs
+++ b/Sources/EventViewerX/Rules/ActiveDirectory/GroupPolicies/GpoDeleted.cs
@@ -1,0 +1,20 @@
+namespace EventViewerX.Rules.ActiveDirectory;
+
+public class GpoDeleted : EventObjectSlim {
+    public string Computer;
+    public string Action;
+    public string GpoName;
+    public string Who;
+    public DateTime When;
+
+    public GpoDeleted(EventObject eventObject) : base(eventObject) {
+        _eventObject = eventObject;
+        Type = "GpoDeleted";
+        Computer = _eventObject.ComputerName;
+        Action = _eventObject.MessageSubject;
+        GpoName = _eventObject.GetValueFromDataDictionary("ObjectDN");
+        Who = _eventObject.GetValueFromDataDictionary("SubjectUserName", "SubjectDomainName", "\\", reverseOrder: true);
+        When = _eventObject.TimeCreated;
+    }
+}
+

--- a/Sources/EventViewerX/Rules/ActiveDirectory/GroupPolicies/GpoModified.cs
+++ b/Sources/EventViewerX/Rules/ActiveDirectory/GroupPolicies/GpoModified.cs
@@ -1,0 +1,24 @@
+namespace EventViewerX.Rules.ActiveDirectory;
+
+public class GpoModified : EventObjectSlim {
+    public string Computer;
+    public string Action;
+    public string GpoName;
+    public string AttributeLDAPDisplayName;
+    public string AttributeValue;
+    public string Who;
+    public DateTime When;
+
+    public GpoModified(EventObject eventObject) : base(eventObject) {
+        _eventObject = eventObject;
+        Type = "GpoModified";
+        Computer = _eventObject.ComputerName;
+        Action = _eventObject.MessageSubject;
+        GpoName = _eventObject.GetValueFromDataDictionary("ObjectDN");
+        AttributeLDAPDisplayName = _eventObject.GetValueFromDataDictionary("AttributeLDAPDisplayName");
+        AttributeValue = _eventObject.GetValueFromDataDictionary("AttributeValue");
+        Who = _eventObject.GetValueFromDataDictionary("SubjectUserName", "SubjectDomainName", "\\", reverseOrder: true);
+        When = _eventObject.TimeCreated;
+    }
+}
+

--- a/Sources/EventViewerX/SearchEvents.NamedEventsDetails.cs
+++ b/Sources/EventViewerX/SearchEvents.NamedEventsDetails.cs
@@ -57,6 +57,19 @@ namespace EventViewerX {
         ADGroupPolicyLinks,
 
         /// <summary>
+        /// Group Policy Object created
+        /// </summary>
+        GpoCreated,
+        /// <summary>
+        /// Group Policy Object deleted
+        /// </summary>
+        GpoDeleted,
+        /// <summary>
+        /// Group Policy Object modified
+        /// </summary>
+        GpoModified,
+
+        /// <summary>
         /// Summary of LDAP binding activity
         /// </summary>
         ADLdapBindingSummary,
@@ -165,6 +178,9 @@ namespace EventViewerX {
             { NamedEvents.ADGroupPolicyChanges, ([5136, 5137, 5141], "Security")},
             { NamedEvents.ADGroupPolicyEdits, ([5136, 5137, 5141], "Security")},
             { NamedEvents.ADGroupPolicyLinks, ([5136, 5137, 5141], "Security")},
+            { NamedEvents.GpoCreated, (new List<int> { 5137 }, "Security") },
+            { NamedEvents.GpoDeleted, (new List<int> { 5141 }, "Security") },
+            { NamedEvents.GpoModified, (new List<int> { 5136 }, "Security") },
             // user based events
             { NamedEvents.ADUserCreateChange, ([4720, 4738], "Security") },
             { NamedEvents.ADUserStatus, ([4722, 4725, 4723, 4724, 4726], "Security") },
@@ -319,6 +335,21 @@ namespace EventViewerX {
                                 && ldapDisplayObjName is string ldapDisplayNameValue
                                 && ldapDisplayNameValue == "versionNumber") {
                                 return new ADGroupPolicyEdits(eventObject);
+                            }
+                            break;
+                        case NamedEvents.GpoCreated:
+                            if (objectClass == "groupPolicyContainer") {
+                                return new GpoCreated(eventObject);
+                            }
+                            break;
+                        case NamedEvents.GpoDeleted:
+                            if (objectClass == "groupPolicyContainer") {
+                                return new GpoDeleted(eventObject);
+                            }
+                            break;
+                        case NamedEvents.GpoModified:
+                            if (objectClass == "groupPolicyContainer") {
+                                return new GpoModified(eventObject);
                             }
                             break;
 


### PR DESCRIPTION
## Summary
- add new classes `GpoCreated`, `GpoDeleted` and `GpoModified`
- register the new events in `NamedEvents` and map their IDs
- update `BuildTargetEvents` to return the new classes

## Testing
- `dotnet build Sources/EventViewerX.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_685fe1159fbc832eb2cf83d8351ce738