### PR TITLE
Add PSD1 refresh step in PowerShell CI

### DIFF
--- a/.github/workflows/test-powershell.yml
+++ b/.github/workflows/test-powershell.yml
@@ -17,12 +17,44 @@ env:
   BUILD_CONFIGURATION: 'Debug'
 
 jobs:
+  refresh-psd1:
+    name: 'Refresh PSD1'
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PowerShell modules
+        run: |
+          Install-Module PSPublishModule -Force -Scope CurrentUser -AllowClobber
+        shell: pwsh
+
+      - name: Refresh module manifest
+        env:
+          RefreshPSD1Only: 'true'
+        run: |
+          .\Build\Manage-Module.ps1
+        shell: pwsh
+
+      - name: Upload refreshed manifest
+        uses: actions/upload-artifact@v4
+        with:
+          name: psd1
+          path: PSEventViewer.psd1
+
   test-windows-ps5:
+    needs: refresh-psd1
     name: 'Windows PowerShell 5.1'
     runs-on: windows-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Download manifest
+        uses: actions/download-artifact@v4
+        with:
+          name: psd1
+          path: .
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
@@ -46,11 +78,18 @@ jobs:
         run: .\PSEventViewer.Tests.ps1
 
   test-windows-ps7:
+    needs: refresh-psd1
     name: 'Windows PowerShell 7'
     runs-on: windows-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Download manifest
+        uses: actions/download-artifact@v4
+        with:
+          name: psd1
+          path: .
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
@@ -72,3 +111,4 @@ jobs:
       - name: Run PowerShell tests
         shell: pwsh
         run: .\PSEventViewer.Tests.ps1
+


### PR DESCRIPTION
## Summary
- refresh module manifest before running PowerShell tests
- download refreshed manifest for each test job

## Testing
- `dotnet restore Sources/EventViewerX.sln`
- `dotnet build Sources/EventViewerX.sln --configuration Debug --no-restore`
- `dotnet test Sources/EventViewerX.sln --configuration Debug --no-build --verbosity minimal`
- `pwsh ./PSEventViewer.Tests.ps1` *(fails: required modules unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_685fe9501a60832eb8e3bd70cc60e592