### PR TITLE
Add Kerberos ticket event parser

### DIFF
--- a/Sources/EventViewerX/Rules/Kerberos/KerberosServiceTicket.cs
+++ b/Sources/EventViewerX/Rules/Kerberos/KerberosServiceTicket.cs
@@ -1,0 +1,38 @@
+namespace EventViewerX.Rules.Kerberos;
+
+public class KerberosServiceTicket : EventObjectSlim
+{
+    public string Computer;
+    public string Action;
+    public string AccountName;
+    public string ServiceName;
+    public string IpAddress;
+    public string IpPort;
+    public string TicketOptions;
+    public TicketEncryptionType? EncryptionType;
+    public bool WeakEncryptionAlgorithm;
+    public bool UnusualTicketOptions;
+    public DateTime When;
+
+    public KerberosServiceTicket(EventObject eventObject) : base(eventObject)
+    {
+        _eventObject = eventObject;
+        Type = "KerberosServiceTicket";
+        Computer = _eventObject.ComputerName;
+        Action = _eventObject.MessageSubject;
+        AccountName = _eventObject.GetValueFromDataDictionary("TargetUserName", "TargetDomainName", "\\", reverseOrder: true);
+        ServiceName = _eventObject.GetValueFromDataDictionary("ServiceName");
+        IpAddress = _eventObject.GetValueFromDataDictionary("IpAddress");
+        IpPort = _eventObject.GetValueFromDataDictionary("IpPort");
+        TicketOptions = _eventObject.GetValueFromDataDictionary("TicketOptions");
+        EncryptionType = EventsHelper.GetTicketEncryptionType(_eventObject.GetValueFromDataDictionary("TicketEncryptionType"));
+        When = _eventObject.TimeCreated;
+
+        WeakEncryptionAlgorithm = EncryptionType is TicketEncryptionType.DES_CBC_CRC
+            or TicketEncryptionType.DES_CBC_MD5
+            or TicketEncryptionType.RC4_HMAC
+            or TicketEncryptionType.RC4_HMAC_EXP;
+
+        UnusualTicketOptions = !(TicketOptions?.Equals("0x40810010", StringComparison.OrdinalIgnoreCase) ?? false);
+    }
+}

--- a/Sources/EventViewerX/Rules/Kerberos/KerberosTicketFailure.cs
+++ b/Sources/EventViewerX/Rules/Kerberos/KerberosTicketFailure.cs
@@ -1,0 +1,33 @@
+namespace EventViewerX.Rules.Kerberos;
+
+public class KerberosTicketFailure : EventObjectSlim
+{
+    public string Computer;
+    public string Action;
+    public string AccountName;
+    public string FailureCode;
+    public string IpAddress;
+    public string IpPort;
+    public TicketEncryptionType? EncryptionType;
+    public bool WeakEncryptionAlgorithm;
+    public DateTime When;
+
+    public KerberosTicketFailure(EventObject eventObject) : base(eventObject)
+    {
+        _eventObject = eventObject;
+        Type = "KerberosTicketFailure";
+        Computer = _eventObject.ComputerName;
+        Action = _eventObject.MessageSubject;
+        AccountName = _eventObject.GetValueFromDataDictionary("TargetUserName", "TargetDomainName", "\\", reverseOrder: true);
+        FailureCode = _eventObject.GetValueFromDataDictionary("Status");
+        IpAddress = _eventObject.GetValueFromDataDictionary("IpAddress");
+        IpPort = _eventObject.GetValueFromDataDictionary("IpPort");
+        EncryptionType = EventsHelper.GetTicketEncryptionType(_eventObject.GetValueFromDataDictionary("TicketEncryptionType"));
+        When = _eventObject.TimeCreated;
+
+        WeakEncryptionAlgorithm = EncryptionType is TicketEncryptionType.DES_CBC_CRC
+            or TicketEncryptionType.DES_CBC_MD5
+            or TicketEncryptionType.RC4_HMAC
+            or TicketEncryptionType.RC4_HMAC_EXP;
+    }
+}

--- a/Sources/EventViewerX/SearchEvents.NamedEventsDetails.cs
+++ b/Sources/EventViewerX/SearchEvents.NamedEventsDetails.cs
@@ -1,6 +1,7 @@
 ﻿using EventViewerX.Rules.ActiveDirectory;
 using EventViewerX.Rules.Logging;
 using EventViewerX.Rules.Windows;
+using EventViewerX.Rules.Kerberos;
 using System;
 using System.Collections.Generic;
 
@@ -114,6 +115,14 @@ namespace EventViewerX {
         /// </summary>
         ADUserUnlocked,
         /// <summary>
+        /// Kerberos service ticket requests and renewals
+        /// </summary>
+        KerberosServiceTicket,
+        /// <summary>
+        /// Kerberos ticket request failures
+        /// </summary>
+        KerberosTicketFailure,
+        /// <summary>
         /// Organizational unit created, deleted or moved
         /// </summary>
         ADOrganizationalUnitChangeDetailed,
@@ -192,6 +201,8 @@ namespace EventViewerX {
             { NamedEvents.ADUserLogonFailed, ([4625], "Security")},
             { NamedEvents.ADUserLogonKerberos, ([4768], "Security") },
             { NamedEvents.ADUserUnlocked, ([4767], "Security") },
+            { NamedEvents.KerberosServiceTicket, (new List<int> { 4769, 4770 }, "Security") },
+            { NamedEvents.KerberosTicketFailure, (new List<int> { 4771, 4772 }, "Security") },
             // other based events
             { NamedEvents.ADOtherChangeDetailed, (new List<int> { 5136, 5137, 5139, 5141 }, "Security") },
             // ldap events
@@ -286,6 +297,10 @@ namespace EventViewerX {
                             return new ADUserLogonFailed(eventObject);
                         case NamedEvents.ADUserUnlocked:
                             return new ADUserUnlocked(eventObject);
+                        case NamedEvents.KerberosServiceTicket:
+                            return new KerberosServiceTicket(eventObject);
+                        case NamedEvents.KerberosTicketFailure:
+                            return new KerberosTicketFailure(eventObject);
                         // organizational unit and other events
                         case NamedEvents.ADOrganizationalUnitChangeDetailed:
                             if (objectClass == "organizationalUnit" && eventObject.Data["AttributeLDAPDisplayName"] != "qPLik") {


### PR DESCRIPTION
## Summary
- support Kerberos ticket events
- detect weak encryption algorithms and unexpected options

## Testing
- `dotnet build Sources/EventViewerX/EventViewerX.csproj -c Release`
- `dotnet build Sources/PSEventViewer/PSEventViewer.csproj -c Release`
- `pwsh -NoLogo -NoProfile -Command ./PSEventViewer.Tests.ps1` *(fails: Write-Color/Invoke-Pester not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860399a81dc832e9304fa4207d559bb