### PR TITLE
Add ClientGroupPolicies event class

### DIFF
--- a/Sources/EventViewerX/Rules/Windows/ClientGroupPolicies.cs
+++ b/Sources/EventViewerX/Rules/Windows/ClientGroupPolicies.cs
@@ -1,85 +1,25 @@
-﻿namespace EventViewerX.Rules.Windows;
+namespace EventViewerX.Rules.Windows;
 
-internal class ClientGroupPolicies {
-    //Log Name:      Application
-    // Source:        Group Policy Files
-    // Date:          10.02.2024 16:10:50
-    // Event ID:      4098
-    // Task Category: (2)
-    // Level:         Warning
-    // Keywords:      Classic
-    // User:          SYSTEM
-    // Computer:      EVOMONSTER.ad.evotec.xyz
-    // Description:
-    // The computer 'Install.ps1' preference item in the 'CopyFiles {76CA620F-5CEB-4316-A0D1-9311E6EE03B9}' Group Policy Object did not apply because it failed with error code '0x80070035 The network path was not found.' This error was suppressed.
-    // Event Xml:
-    // <Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
-    //   <System>
-    //     <Provider Name="Group Policy Files" />
-    //     <EventID Qualifiers="34305">4098</EventID>
-    //     <Version>0</Version>
-    //     <Level>3</Level>
-    //     <Task>2</Task>
-    //     <Opcode>0</Opcode>
-    //     <Keywords>0x80000000000000</Keywords>
-    //     <TimeCreated SystemTime="2024-02-10T15:10:50.0074671Z" />
-    //     <EventRecordID>22479</EventRecordID>
-    //     <Correlation />
-    //     <Execution ProcessID="1160" ThreadID="0" />
-    //     <Channel>Application</Channel>
-    //     <Computer>EVOMONSTER.ad.evotec.xyz</Computer>
-    //     <Security UserID="S-1-5-18" />
-    //   </System>
-    //   <EventData>
-    //     <Data>computer</Data>
-    //     <Data>Install.ps1</Data>
-    //     <Data>CopyFiles {76CA620F-5CEB-4316-A0D1-9311E6EE03B9}</Data>
-    //     <Data>0x80070035 The network path was not found.</Data>
-    //   </EventData>
-    // </Event>
+public class ClientGroupPolicies : EventObjectSlim {
+    public string Computer;
+    public string Action;
+    public string PolicyScope;
+    public string ItemName;
+    public string PolicyName;
+    public string Error;
+    public string Who;
+    public DateTime When;
 
-
-
-
-    //Log Name:      System
-    // Source:        Microsoft-Windows-GroupPolicy
-    // Date:          11.02.2024 12:46:49
-    // Event ID:      1085
-    // Task Category: None
-    // Level:         Warning
-    // Keywords:      
-    // User:          SYSTEM
-    // Computer:      EVOMONSTER.ad.evotec.xyz
-    // Description:
-    // Windows failed to apply the MDM Policy settings. MDM Policy settings might have its own log file. Please click on the "More information" link.
-    // Event Xml:
-    // <Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
-    //   <System>
-    //     <Provider Name="Microsoft-Windows-GroupPolicy" Guid="{aea1b4fa-97d1-45f2-a64c-4d69fffd92c9}" />
-    //     <EventID>1085</EventID>
-    //     <Version>0</Version>
-    //     <Level>3</Level>
-    //     <Task>0</Task>
-    //     <Opcode>1</Opcode>
-    //     <Keywords>0x8000000000000000</Keywords>
-    //     <TimeCreated SystemTime="2024-02-11T11:46:49.9245620Z" />
-    //     <EventRecordID>34081</EventRecordID>
-    //     <Correlation ActivityID="{cc36e32c-163a-4f85-872e-e4c5a1a74bcb}" />
-    //     <Execution ProcessID="1160" ThreadID="11620" />
-    //     <Channel>System</Channel>
-    //     <Computer>EVOMONSTER.ad.evotec.xyz</Computer>
-    //     <Security UserID="S-1-5-18" />
-    //   </System>
-    //   <EventData>
-    //     <Data Name="SupportInfo1">1</Data>
-    //     <Data Name="SupportInfo2">5213</Data>
-    //     <Data Name="ProcessingMode">0</Data>
-    //     <Data Name="ProcessingTimeInMilliseconds">641</Data>
-    //     <Data Name="ErrorCode">2149056522</Data>
-    //     <Data Name="ErrorDescription">The device is already enrolled. </Data>
-    //     <Data Name="DCName">\\AD1.ad.evotec.xyz</Data>
-    //     <Data Name="ExtensionName">MDM Policy</Data>
-    //     <Data Name="ExtensionId">{7909AD9E-09EE-4247-BAB9-7029D5F0A278}</Data>
-    //   </EventData>
-    // </Event>
+    public ClientGroupPolicies(EventObject eventObject) : base(eventObject) {
+        _eventObject = eventObject;
+        Type = "ClientGroupPolicies";
+        Computer = _eventObject.ComputerName;
+        Action = _eventObject.MessageSubject;
+        PolicyScope = _eventObject.GetValueFromDataDictionary("NoNameA0");
+        ItemName = _eventObject.GetValueFromDataDictionary("NoNameA1");
+        PolicyName = _eventObject.GetValueFromDataDictionary("NoNameA2", "ExtensionName");
+        Error = _eventObject.GetValueFromDataDictionary("NoNameA3", "ErrorDescription");
+        Who = _eventObject.GetValueFromDataDictionary("SubjectUserName", "SubjectDomainName", "\\", reverseOrder: true);
+        When = _eventObject.TimeCreated;
+    }
 }

--- a/Sources/EventViewerX/SearchEvents.NamedEventsDetails.cs
+++ b/Sources/EventViewerX/SearchEvents.NamedEventsDetails.cs
@@ -166,6 +166,14 @@ namespace EventViewerX {
         /// System time changed
         /// </summary>
         OSTimeChange,
+        /// <summary>
+        /// Group Policy client-side processing events from Application log
+        /// </summary>
+        ClientGroupPoliciesApplication,
+        /// <summary>
+        /// Group Policy client-side processing events from System log
+        /// </summary>
+        ClientGroupPoliciesSystem,
     }
 
     public partial class SearchEvents : Settings {
@@ -220,6 +228,8 @@ namespace EventViewerX {
             { NamedEvents.OSCrash, (new List<int> { 6008 }, "System") },
             { NamedEvents.OSStartupShutdownCrash,  (new List<int> { 12, 13, 41, 4608, 4621, 6008 }, "System") },
             { NamedEvents.OSTimeChange, (new List<int> { 4616 }, "Security") },
+            { NamedEvents.ClientGroupPoliciesApplication, (new List<int> { 4098 }, "Application") },
+            { NamedEvents.ClientGroupPoliciesSystem, (new List<int> { 1085 }, "System") },
         };
         /// <summary>
         /// Builds the appropriate event object based on the NamedEvents value
@@ -331,6 +341,9 @@ namespace EventViewerX {
                             return new OSStartupShutdownCrash(eventObject);
                         case NamedEvents.OSTimeChange:
                             return new OSTimeChange(eventObject);
+                        case NamedEvents.ClientGroupPoliciesApplication:
+                        case NamedEvents.ClientGroupPoliciesSystem:
+                            return new ClientGroupPolicies(eventObject);
                         case NamedEvents.ADSMBServerAuditV1:
                             return SMBServerAudit.Create(eventObject);
                         case NamedEvents.ADGroupPolicyChanges:


### PR DESCRIPTION
## Summary
- convert `ClientGroupPolicies.cs` from comments to real `EventObjectSlim`
- map Group Policy client events to new named events
- support building ClientGroupPolicies objects in SearchEvents

## Testing
- `dotnet build Sources/EventViewerX.sln -c Release`
- `dotnet test Sources/EventViewerX.sln -c Release`


------
https://chatgpt.com/codex/tasks/task_e_6860daa459ec832e95115abb796ee25f