### PR TITLE
Add CertificateIssued rule

### DIFF
--- a/Sources/EventViewerX/Rules/CertificateAuthority/CertificateIssued.cs
+++ b/Sources/EventViewerX/Rules/CertificateAuthority/CertificateIssued.cs
@@ -1,0 +1,56 @@
+namespace EventViewerX.Rules.CertificateAuthority;
+
+/// <summary>
+/// Certificate issued by Certificate Authority
+/// 4886: Certificate Services received a certificate request
+/// 4887: Certificate Services approved a certificate request and issued a certificate
+/// </summary>
+public class CertificateIssued : EventObjectSlim
+{
+    public string Computer;
+    public string Action;
+    public string CertificateTemplate;
+    public string Requester;
+    public string SerialNumber;
+    public string Who;
+    public DateTime When;
+
+    public CertificateIssued(EventObject eventObject) : base(eventObject)
+    {
+        _eventObject = eventObject;
+        Type = "CertificateIssued";
+        Computer = _eventObject.ComputerName;
+        Action = _eventObject.MessageSubject;
+        CertificateTemplate = DecodeHex(_eventObject.GetValueFromDataDictionary("CertificateTemplate", "CertificateTemplateOid"));
+        Requester = DecodeHex(_eventObject.GetValueFromDataDictionary("Requester", "RequestSubjectName"));
+        SerialNumber = DecodeHex(_eventObject.GetValueFromDataDictionary("SerialNumber"));
+        Who = _eventObject.GetValueFromDataDictionary("SubjectUserName", "SubjectDomainName", "\\", reverseOrder: true);
+        When = _eventObject.TimeCreated;
+    }
+
+    private static string DecodeHex(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return string.Empty;
+        }
+        value = value.Replace(" ", string.Empty).Replace("0x", string.Empty);
+        if (value.Length % 2 != 0)
+        {
+            return value;
+        }
+        try
+        {
+            byte[] bytes = new byte[value.Length / 2];
+            for (int i = 0; i < bytes.Length; i++)
+            {
+                bytes[i] = Convert.ToByte(value.Substring(i * 2, 2), 16);
+            }
+            return System.Text.Encoding.ASCII.GetString(bytes);
+        }
+        catch
+        {
+            return value;
+        }
+    }
+}

--- a/Sources/EventViewerX/SearchEvents.NamedEventsDetails.cs
+++ b/Sources/EventViewerX/SearchEvents.NamedEventsDetails.cs
@@ -2,6 +2,7 @@
 using EventViewerX.Rules.Logging;
 using EventViewerX.Rules.Windows;
 using EventViewerX.Rules.Kerberos;
+using EventViewerX.Rules.CertificateAuthority;
 using System;
 using System.Collections.Generic;
 
@@ -155,6 +156,11 @@ namespace EventViewerX {
         NetworkAccessAuthenticationPolicy,
 
         /// <summary>
+        /// Certificate issued by Certificate Authority
+        /// </summary>
+        CertificateIssued,
+
+        /// <summary>
         /// Unexpected system shutdown
         /// </summary>
         OSCrash,
@@ -224,6 +230,7 @@ namespace EventViewerX {
             { NamedEvents.LogsFullSecurity, (new List<int> { 1104  }, "Security") },
             // network access
             { NamedEvents.NetworkAccessAuthenticationPolicy, (new List<int> { 6272, 6273 }, "Security") },
+            { NamedEvents.CertificateIssued, (new List<int> { 4886, 4887 }, "Security") },
             // windows OS
             { NamedEvents.OSCrash, (new List<int> { 6008 }, "System") },
             { NamedEvents.OSStartupShutdownCrash,  (new List<int> { 12, 13, 41, 4608, 4621, 6008 }, "System") },
@@ -335,6 +342,8 @@ namespace EventViewerX {
                             return new LogsClearedSecurity(eventObject);
                         case NamedEvents.LogsClearedOther:
                             return new LogsClearedOther(eventObject);
+                        case NamedEvents.CertificateIssued:
+                            return new CertificateIssued(eventObject);
                         case NamedEvents.OSCrash:
                             return new OSCrash(eventObject);
                         case NamedEvents.OSStartupShutdownCrash:


### PR DESCRIPTION
## Summary
- add new CertificateIssued rule to decode certificate info
- register CertificateIssued events with NamedEvents

## Testing
- `dotnet build Sources/EventViewerX.sln` *(fails: Assets file not found without restore)*
- `dotnet build Sources/EventViewerX.sln`

------
https://chatgpt.com/codex/tasks/task_e_6860e0adf280832ea24b646ec003025c