### PR TITLE
Add AuditPolicyChange rule

### DIFF
--- a/Sources/EventViewerX/Rules/Windows/AuditPolicyChange.cs
+++ b/Sources/EventViewerX/Rules/Windows/AuditPolicyChange.cs
@@ -1,0 +1,27 @@
+namespace EventViewerX.Rules.Windows;
+
+/// <summary>
+/// System audit policy was changed
+/// 4719: System audit policy was changed
+/// </summary>
+public class AuditPolicyChange : EventObjectSlim {
+    public string Computer;
+    public string CategoryId;
+    public string SubcategoryId;
+    public string SubcategoryGuid;
+    public string AuditPolicyChanges;
+    public string Who;
+    public DateTime When;
+
+    public AuditPolicyChange(EventObject eventObject) : base(eventObject) {
+        _eventObject = eventObject;
+        Type = "AuditPolicyChange";
+        Computer = _eventObject.ComputerName;
+        CategoryId = _eventObject.GetValueFromDataDictionary("CategoryId");
+        SubcategoryId = _eventObject.GetValueFromDataDictionary("SubcategoryId");
+        SubcategoryGuid = _eventObject.GetValueFromDataDictionary("SubcategoryGuid");
+        AuditPolicyChanges = _eventObject.GetValueFromDataDictionary("AuditPolicyChanges");
+        Who = _eventObject.GetValueFromDataDictionary("SubjectUserName", "SubjectDomainName", "\\", reverseOrder: true);
+        When = _eventObject.TimeCreated;
+    }
+}

--- a/Sources/EventViewerX/SearchEvents.NamedEventsDetails.cs
+++ b/Sources/EventViewerX/SearchEvents.NamedEventsDetails.cs
@@ -161,6 +161,11 @@ namespace EventViewerX {
         CertificateIssued,
 
         /// <summary>
+        /// System audit policy was changed
+        /// </summary>
+        AuditPolicyChange,
+
+        /// <summary>
         /// Unexpected system shutdown
         /// </summary>
         OSCrash,
@@ -231,6 +236,7 @@ namespace EventViewerX {
             // network access
             { NamedEvents.NetworkAccessAuthenticationPolicy, (new List<int> { 6272, 6273 }, "Security") },
             { NamedEvents.CertificateIssued, (new List<int> { 4886, 4887 }, "Security") },
+            { NamedEvents.AuditPolicyChange, (new List<int> { 4719 }, "Security") },
             // windows OS
             { NamedEvents.OSCrash, (new List<int> { 6008 }, "System") },
             { NamedEvents.OSStartupShutdownCrash,  (new List<int> { 12, 13, 41, 4608, 4621, 6008 }, "System") },
@@ -344,6 +350,8 @@ namespace EventViewerX {
                             return new LogsClearedOther(eventObject);
                         case NamedEvents.CertificateIssued:
                             return new CertificateIssued(eventObject);
+                        case NamedEvents.AuditPolicyChange:
+                            return new AuditPolicyChange(eventObject);
                         case NamedEvents.OSCrash:
                             return new OSCrash(eventObject);
                         case NamedEvents.OSStartupShutdownCrash:


### PR DESCRIPTION
## Summary
- add AuditPolicyChange.cs rule parsing audit policy changes (event 4719)
- register AuditPolicyChange in NamedEvents mapping

## Testing
- `dotnet build Sources/EventViewerX/EventViewerX.csproj -c Release`
- `dotnet build Sources/EventViewerX.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6860e6d9949c832e968bbae3ebf8cc4f