### PR TITLE
Extend Find-WinEvent with message filtering

### DIFF
--- a/Tests/Get-EVXEvent.Tests.ps1
+++ b/Tests/Get-EVXEvent.Tests.ps1
@@ -155,3 +155,12 @@ Describe 'Get-EVXEvent - Read events with NamedDataFilter' {
 
     }
 }
+
+Describe 'Get-EVXEvent - MessageRegex' {
+    $FilePath = [System.IO.Path]::Combine($PSScriptRoot, 'Logs', 'Active Directory Web Services.evtx')
+
+    It 'Supports filtering by message regex' {
+        $events = Get-EVXEvent -Path $FilePath -MaxEvents 1 -MessageRegex '.*'
+        $events.Count | Should -Be 1
+    }
+}

--- a/Tests/Get-EVXEvent.Tests.ps1
+++ b/Tests/Get-EVXEvent.Tests.ps1
@@ -157,10 +157,9 @@ Describe 'Get-EVXEvent - Read events with NamedDataFilter' {
 }
 
 Describe 'Get-EVXEvent - MessageRegex' {
-    $FilePath = [System.IO.Path]::Combine($PSScriptRoot, 'Logs', 'Active Directory Web Services.evtx')
-
     It 'Supports filtering by message regex' {
-        $events = Get-EVXEvent -Path $FilePath -MaxEvents 1 -MessageRegex '.*'
+        $FilePath = [System.IO.Path]::Combine($PSScriptRoot, 'Logs', 'Active Directory Web Services.evtx')
+        $events   = Get-EVXEvent -Path $FilePath -MaxEvents 1 -MessageRegex '.*'
         $events.Count | Should -Be 1
     }
 }


### PR DESCRIPTION
## Summary
- add `MessageRegex` parameter for `Find-WinEvent`
- filter output using the provided regex
- basic test demonstrating the new parameter

## Testing
- `dotnet build Sources/PSEventViewer/PSEventViewer.csproj -c Release`
- `pwsh -NoLogo -NoProfile -Command ./PSEventViewer.Tests.ps1` *(fails: The term 'Invoke-Pester' is not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_6860e7905900832eb03db3616f964d79