### PR TITLE
Refactor named event registration

### DIFF
--- a/Sources/EventViewerX/SearchEvents.QueryNamedEvents.cs
+++ b/Sources/EventViewerX/SearchEvents.QueryNamedEvents.cs
@@ -10,12 +10,9 @@ namespace EventViewerX {
             var eventInfoDict = new Dictionary<string, HashSet<int>>();
 
             foreach (var typeEvents in typeEventsList) {
-                // Look up the list of event IDs and the log name based on typeEvents
-                if (!eventIdsMap.TryGetValue(typeEvents, out var eventInfo)) {
+                if (!eventDefinitions.TryGetValue(typeEvents, out var eventInfo)) {
                     throw new ArgumentException($"Invalid typeEvents value: {typeEvents}");
                 }
-
-                // Add the event IDs to the dictionary
                 if (!eventInfoDict.TryGetValue(eventInfo.LogName, out var eventIds)) {
                     eventIds = new HashSet<int>();
                     eventInfoDict[eventInfo.LogName] = eventIds;


### PR DESCRIPTION
## Summary
- replace large switch/lookup with configurable list
- build dictionary from definitions at runtime
- simplify BuildTargetEvents to use definition builder

## Testing
- `dotnet build Sources/EventViewerX/EventViewerX.csproj -c Release`
- `pwsh -NoLogo -NoProfile -Command ./PSEventViewer.Tests.ps1` *(fails: Write-Color not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_6860ed4647a0832ea8796100ee61cef4