### PR TITLE
Add PowerShell script restore functions

### DIFF
--- a/PSEventViewer.psd1
+++ b/PSEventViewer.psd1
@@ -1,7 +1,7 @@
 ﻿@{
-    AliasesToExport      = @('Get-EventViewerXEvent', 'Find-WinEvent', 'Get-Events', 'Get-EventViewerXFilter', 'Get-WinEventFilter', 'Get-EventsFilter', 'Get-EventViewerXInfo', 'Get-EventsSettings', 'Get-EventsInformation', 'Get-EventViewerXProviderList', 'Remove-EventViewerXSource', 'Remove-WinEventSource', 'Set-EventViewerXInfo', 'Set-EventsInformation', 'Set-EventsSettings', 'Start-EventViewerXWatcher', 'Start-EventWatching', 'Write-EventViewerXEntry', 'Write-WinEvent')
+    AliasesToExport      = @('Get-EventViewerXEvent', 'Find-WinEvent', 'Get-Events', 'Get-EventViewerXFilter', 'Get-WinEventFilter', 'Get-EventsFilter', 'Get-EventViewerXInfo', 'Get-EventsSettings', 'Get-EventsInformation', 'Get-EventViewerXProviderList', 'Remove-EventViewerXSource', 'Remove-WinEventSource', 'Set-EventViewerXInfo', 'Set-EventsInformation', 'Set-EventsSettings', 'Start-EventViewerXWatcher', 'Start-EventWatching', 'Write-EventViewerXEntry', 'Write-WinEvent', 'Get-PowerShellScriptExecution', 'Restore-PowerShellScript')
     Author               = 'Przemyslaw Klys'
-    CmdletsToExport      = @('Get-EVXEvent', 'Get-EVXFilter', 'Get-EVXInfo', 'Get-EVXProviderList', 'Remove-EVXSource', 'Set-EVXInfo', 'Start-EVXWatcher', 'Write-EVXEntry')
+    CmdletsToExport      = @('Get-EVXEvent', 'Get-EVXFilter', 'Get-EVXInfo', 'Get-EVXProviderList', 'Remove-EVXSource', 'Set-EVXInfo', 'Start-EVXWatcher', 'Write-EVXEntry', 'Get-EVXPowerShellScriptExecution', 'Restore-EVXPowerShellScript')
     CompanyName          = 'Evotec'
     CompatiblePSEditions = @('Desktop', 'Core')
     Copyright            = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'

--- a/Sources/EventViewerX/Definitions/PowerShellEdition.cs
+++ b/Sources/EventViewerX/Definitions/PowerShellEdition.cs
@@ -1,0 +1,6 @@
+namespace EventViewerX;
+
+public enum PowerShellEdition {
+    PowerShell,
+    WindowsPowerShell
+}

--- a/Sources/EventViewerX/PowerShellScriptExecutionInfo.cs
+++ b/Sources/EventViewerX/PowerShellScriptExecutionInfo.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using System.Diagnostics.Eventing.Reader;
+
+namespace EventViewerX {
+    /// <summary>
+    /// Represents details of a PowerShell engine start event.
+    /// </summary>
+    public class PowerShellScriptExecutionInfo {
+        public EventRecord EventRecord { get; }
+        public IDictionary<string, string?> Data { get; }
+
+        internal PowerShellScriptExecutionInfo(EventRecord record, IDictionary<string, string?> data) {
+            EventRecord = record;
+            Data = data;
+        }
+    }
+
+    /// <summary>
+    /// Represents a reconstructed PowerShell script from event logs.
+    /// </summary>
+    public class RestoredPowerShellScript {
+        public string ScriptBlockId { get; set; }
+        public string Script { get; set; }
+        public EventRecord EventRecord { get; set; }
+        public IDictionary<string, string?> Data { get; set; }
+    }
+}

--- a/Sources/EventViewerX/SearchEvents.PowerShellScripts.cs
+++ b/Sources/EventViewerX/SearchEvents.PowerShellScripts.cs
@@ -1,0 +1,196 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Eventing.Reader;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+
+namespace EventViewerX {
+    public partial class SearchEvents {
+        public static IEnumerable<PowerShellScriptExecutionInfo> GetPowerShellScriptExecution(
+            PowerShellEdition type,
+            string machineName = null,
+            string eventLogPath = null,
+            DateTime? dateFrom = null,
+            DateTime? dateTo = null) {
+            string logName = type == PowerShellEdition.WindowsPowerShell
+                ? "Microsoft-Windows-PowerShell/Operational"
+                : "PowerShellCore/Operational";
+
+            string queryString = BuildWinEventFilter(
+                id: new[] { "4100" },
+                startTime: dateFrom,
+                endTime: dateTo,
+                logName: logName,
+                path: eventLogPath,
+                xpathOnly: false);
+
+            EventLogQuery query = string.IsNullOrEmpty(eventLogPath)
+                ? new EventLogQuery(logName, PathType.LogName, queryString)
+                : new EventLogQuery(null, PathType.LogName, queryString);
+            if (!string.IsNullOrEmpty(machineName)) {
+                query.Session = new EventLogSession(machineName);
+            }
+
+            using EventLogReader reader = CreateEventLogReader(query, machineName);
+            if (reader == null) {
+                yield break;
+            }
+
+            EventRecord record;
+            while ((record = reader.ReadEvent()) != null) {
+                string contextInfo = ExtractData(record, "ContextInfo");
+                var data = ParseContextInfo(contextInfo);
+                yield return new PowerShellScriptExecutionInfo(record, data);
+            }
+        }
+
+        public static IEnumerable<RestoredPowerShellScript> RestorePowerShellScripts(
+            PowerShellEdition type,
+            string machineName = null,
+            string eventLogPath = null,
+            DateTime? dateFrom = null,
+            DateTime? dateTo = null,
+            bool format = false,
+            IEnumerable<string> containsText = null) {
+            string logName = type == PowerShellEdition.WindowsPowerShell
+                ? "Microsoft-Windows-PowerShell/Operational"
+                : "PowerShellCore/Operational";
+
+            string queryString = BuildWinEventFilter(
+                id: new[] { "4103", "4104" },
+                startTime: dateFrom,
+                endTime: dateTo,
+                logName: logName,
+                path: eventLogPath,
+                xpathOnly: false);
+
+            EventLogQuery query = string.IsNullOrEmpty(eventLogPath)
+                ? new EventLogQuery(logName, PathType.LogName, queryString)
+                : new EventLogQuery(null, PathType.LogName, queryString);
+            if (!string.IsNullOrEmpty(machineName)) {
+                query.Session = new EventLogSession(machineName);
+            }
+
+            using EventLogReader reader = CreateEventLogReader(query, machineName);
+            if (reader == null) {
+                yield break;
+            }
+
+            var cache = new Dictionary<string, Dictionary<string, object>>();
+            EventRecord record;
+            while ((record = reader.ReadEvent()) != null) {
+                string scriptText = ExtractData(record, "ScriptBlockText");
+                if (string.IsNullOrEmpty(scriptText) || scriptText == "0") {
+                    continue;
+                }
+                string scriptId = ExtractData(record, "ScriptBlockId");
+                if (scriptId == null) {
+                    continue;
+                }
+                string messageNumber = ExtractData(record, "MessageNumber") ?? "0";
+                if (!cache.TryGetValue(scriptId, out var inner)) {
+                    inner = new Dictionary<string, object>();
+                    cache[scriptId] = inner;
+                }
+                inner["0"] = record;
+                inner[messageNumber] = scriptText;
+            }
+
+            foreach (var kv in cache) {
+                var metaRecord = (EventRecord)kv.Value["0"];
+                string totalStr = ExtractData(metaRecord, "MessageTotal") ?? "0";
+                if (!int.TryParse(totalStr, out int total)) total = 0;
+                var sb = new StringBuilder();
+                for (int i = 1; i <= total; i++) {
+                    if (kv.Value.TryGetValue(i.ToString(), out var partObj) && partObj is string part) {
+                        sb.Append(part);
+                    }
+                }
+                string script = sb.ToString();
+                if (containsText != null && containsText.Any()) {
+                    bool all = true;
+                    foreach (var term in containsText) {
+                        if (term == null) continue;
+                        if (script.IndexOf(term, StringComparison.OrdinalIgnoreCase) < 0) {
+                            all = false;
+                            break;
+                        }
+                    }
+                    if (!all) {
+                        continue;
+                    }
+                }
+                if (format) {
+                    script = FormatScript(script);
+                }
+                yield return new RestoredPowerShellScript {
+                    ScriptBlockId = kv.Key,
+                    Script = script,
+                    EventRecord = metaRecord,
+                    Data = GetAllData(metaRecord)
+                };
+            }
+        }
+
+        private static Dictionary<string, string?> ParseContextInfo(string context) {
+            var result = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+            if (string.IsNullOrEmpty(context)) {
+                return result;
+            }
+            var lines = context.Split(new[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries);
+            foreach (var line in lines) {
+                var parts = line.Split(new[] { '=' }, 2);
+                var key = parts[0].Trim().Replace(" ", string.Empty);
+                var value = parts.Length > 1 ? parts[1].Trim() : null;
+                result[key] = value;
+            }
+            return result;
+        }
+
+        private static string ExtractData(EventRecord record, string name) {
+            try {
+                var element = XElement.Parse(record.ToXml());
+                XNamespace ns = element.GetDefaultNamespace();
+                return element.Descendants(ns + "Data")
+                    .FirstOrDefault(e => (string)e.Attribute("Name") == name)?.Value;
+            } catch {
+                return null;
+            }
+        }
+
+        private static Dictionary<string, string?> GetAllData(EventRecord record) {
+            var result = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+            try {
+                var element = XElement.Parse(record.ToXml());
+                XNamespace ns = element.GetDefaultNamespace();
+                foreach (var data in element.Descendants(ns + "Data")) {
+                    var key = (string)data.Attribute("Name");
+                    if (key != null) {
+                        result[key] = data.Value;
+                    }
+                }
+            } catch {
+            }
+            return result;
+        }
+
+        private static string FormatScript(string script) {
+            var sb = new StringBuilder();
+            int indent = 0;
+            var lines = script.Replace("\r", string.Empty).Split('\n');
+            foreach (var raw in lines) {
+                var line = raw.Trim();
+                if (line.StartsWith("}")) {
+                    indent = Math.Max(0, indent - 4);
+                }
+                sb.Append(' ', indent);
+                sb.AppendLine(line);
+                if (line.EndsWith("{")) {
+                    indent += 4;
+                }
+            }
+            return sb.ToString();
+        }
+    }
+}

--- a/Sources/PSEventViewer/CmdletGetEVXPowerShellScriptExecution.cs
+++ b/Sources/PSEventViewer/CmdletGetEVXPowerShellScriptExecution.cs
@@ -1,0 +1,58 @@
+using EventViewerX;
+using System;
+using System.Management.Automation;
+using System.Threading.Tasks;
+
+namespace PSEventViewer {
+    /// <summary>
+    /// Retrieves PowerShell script execution details from event logs.
+    /// </summary>
+    [Cmdlet(VerbsCommon.Get, "EVXPowerShellScriptExecution")]
+    [Alias("Get-PowerShellScriptExecution")]
+    [OutputType(typeof(PowerShellScriptExecutionInfo))]
+    public sealed class CmdletGetEVXPowerShellScriptExecution : AsyncPSCmdlet {
+        /// <summary>
+        /// Edition of PowerShell that generated the logs.
+        /// </summary>
+        [Parameter(Mandatory = true, Position = 0)]
+        public PowerShellEdition Type { get; set; }
+
+        /// <summary>
+        /// Target computers to read events from.
+        /// </summary>
+        [Alias("ComputerName")]
+        [Parameter]
+        public string[] MachineName { get; set; }
+
+        /// <summary>
+        /// Path to an event log file.
+        /// </summary>
+        [Parameter]
+        public string EventLogPath { get; set; }
+
+        /// <summary>
+        /// Start time filter.
+        /// </summary>
+        [Parameter]
+        public DateTime? DateFrom { get; set; }
+
+        /// <summary>
+        /// End time filter.
+        /// </summary>
+        [Parameter]
+        public DateTime? DateTo { get; set; }
+
+        /// <summary>
+        /// Processes the request and returns execution info.
+        /// </summary>
+        protected override Task ProcessRecordAsync() {
+            var machines = MachineName ?? new string[] { null };
+            foreach (var machine in machines) {
+                foreach (var info in SearchEvents.GetPowerShellScriptExecution(Type, machine, EventLogPath, DateFrom, DateTo)) {
+                    WriteObject(info);
+                }
+            }
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Sources/PSEventViewer/CmdletRestoreEVXPowerShellScript.cs
+++ b/Sources/PSEventViewer/CmdletRestoreEVXPowerShellScript.cs
@@ -1,0 +1,94 @@
+using EventViewerX;
+using System;
+using System.IO;
+using System.Management.Automation;
+using System.Threading.Tasks;
+
+namespace PSEventViewer {
+    /// <summary>
+    /// Reconstructs PowerShell scripts from event logs.
+    /// </summary>
+    [Cmdlet(VerbsData.Restore, "EVXPowerShellScript")]
+    [Alias("Restore-PowerShellScript")]
+    [OutputType(typeof(RestoredPowerShellScript))]
+    public sealed class CmdletRestoreEVXPowerShellScript : AsyncPSCmdlet {
+        /// <summary>
+        /// Edition of PowerShell that generated the logs.
+        /// </summary>
+        [Parameter(Mandatory = true, Position = 0)]
+        public PowerShellEdition Type { get; set; }
+
+        /// <summary>
+        /// Target computers to read events from.
+        /// </summary>
+        [Alias("ComputerName")]
+        [Parameter]
+        public string[] MachineName { get; set; }
+
+        /// <summary>
+        /// Path to an event log file.
+        /// </summary>
+        [Parameter]
+        public string EventLogPath { get; set; }
+
+        /// <summary>
+        /// Destination folder for restored scripts. If not specified, scripts are returned.
+        /// </summary>
+        [Parameter]
+        public string Path { get; set; }
+
+        /// <summary>
+        /// Start time filter.
+        /// </summary>
+        [Parameter]
+        public DateTime? DateFrom { get; set; }
+
+        /// <summary>
+        /// End time filter.
+        /// </summary>
+        [Parameter]
+        public DateTime? DateTo { get; set; }
+
+        /// <summary>
+        /// Attempts to format scripts.
+        /// </summary>
+        [Parameter]
+        public SwitchParameter Format { get; set; }
+
+        /// <summary>
+        /// Return only scripts containing these strings.
+        /// </summary>
+        [Parameter]
+        public string[] ContainsText { get; set; }
+
+        /// <summary>
+        /// Processes the request and outputs restored scripts or file paths.
+        /// </summary>
+        protected override Task ProcessRecordAsync() {
+            var machines = MachineName ?? new string[] { null };
+            foreach (var machine in machines) {
+                foreach (var script in SearchEvents.RestorePowerShellScripts(Type, machine, EventLogPath, DateFrom, DateTo, Format.IsPresent, ContainsText)) {
+                    if (!string.IsNullOrEmpty(Path)) {
+                        Directory.CreateDirectory(Path);
+                        string fileName = $"{script.EventRecord.MachineName}_{script.ScriptBlockId}.ps1";
+                        string filePath = System.IO.Path.Combine(Path, fileName);
+                        string header = string.Join(Environment.NewLine,
+                            "<#",
+                            $"RecordID = {script.EventRecord.RecordId}",
+                            $"LogName = {script.EventRecord.LogName}",
+                            $"MachineName = {script.EventRecord.MachineName}",
+                            $"TimeCreated = {script.EventRecord.TimeCreated}",
+                            "#>");
+                        File.WriteAllText(filePath, header + Environment.NewLine + script.Script);
+                        string zonePath = filePath + ":Zone.Identifier";
+                        File.WriteAllText(zonePath, "[ZoneTransfer]\r\nZoneId=3");
+                        WriteObject(filePath);
+                    } else {
+                        WriteObject(script);
+                    }
+                }
+            }
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add PowerShellEdition enum and helper models
- implement `GetPowerShellScriptExecution` and `RestorePowerShellScripts` in C#
- add cmdlets `Get-EVXPowerShellScriptExecution` and `Restore-EVXPowerShellScript`
- support filtering restored scripts and embed metadata headers

## Testing
- `dotnet build Sources/EventViewerX.sln -c Release`
- `dotnet test Sources/EventViewerX.Tests/EventViewerX.Tests.csproj -c Release --no-build`


------
https://chatgpt.com/codex/tasks/task_e_6860e8f06924832e95e72abb1d2fa7c6