### PR TITLE
Add default cases in ConvertSize

### DIFF
--- a/Sources/EventViewerX/EventLogDetails.cs
+++ b/Sources/EventViewerX/EventLogDetails.cs
@@ -102,6 +102,9 @@ public class EventLogDetails {
             case "TB":
                 size *= 1024.0 * 1024.0 * 1024.0 * 1024.0;
                 break;
+            default:
+                // Treat unknown units as bytes
+                break;
         }
 
         switch (toUnit.ToUpper()) {
@@ -118,6 +121,9 @@ public class EventLogDetails {
                 break;
             case "TB":
                 size /= 1024.0 * 1024.0 * 1024.0 * 1024.0;
+                break;
+            default:
+                // Keep size unchanged for unknown units
                 break;
         }
 


### PR DESCRIPTION
## Summary
- guard against unknown units in `ConvertSize`

## Testing
- `dotnet build Sources/EventViewerX.sln -c Release`
- `dotnet test Sources/EventViewerX.Tests/EventViewerX.Tests.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68611d4104c0832eb6f0b0fa18b604bd