### PR TITLE
Fix message null handling

### DIFF
--- a/Sources/EventViewerX/EventObject.cs
+++ b/Sources/EventViewerX/EventObject.cs
@@ -56,7 +56,7 @@ namespace EventViewerX {
 
         public EventBookmark Bookmark => _eventRecord.Bookmark;
 
-        public string Message => _eventRecord.FormatDescription();
+        public string Message => _eventRecord.FormatDescription() ?? string.Empty;
 
         public string TaskDisplayName => _eventRecord.TaskDisplayName;
 


### PR DESCRIPTION
## Summary
- prevent `FormatDescription()` returning null from causing `Message` to be null

## Testing
- `dotnet build Sources/EventViewerX.sln`

------
https://chatgpt.com/codex/tasks/task_e_68611d628a3c832e909848e428b910e9