### PR TITLE
Fix XPath escaping

### DIFF
--- a/Sources/EventViewerX.Tests/TestWinEventFilter.cs
+++ b/Sources/EventViewerX.Tests/TestWinEventFilter.cs
@@ -19,6 +19,13 @@ namespace EventViewerX.Tests {
         }
 
         [Fact]
+        public void NamedDataFilterEscapesSpecialCharacters() {
+            var ht = new Hashtable { { "Field", "O'Reilly & Co" } };
+            var result = SearchEvents.BuildWinEventFilter(namedDataFilter: [ht], logName: "xx", xpathOnly: true);
+            Assert.Equal("*[EventData[Data[@Name='Field'] = 'O&apos;Reilly &amp; Co']]", result);
+        }
+
+        [Fact]
         public void NamedDataExcludeFilterSingleValue() {
             var ht = new Hashtable { { "FieldName", "Value1" } };
             var result = SearchEvents.BuildWinEventFilter(namedDataExcludeFilter: [ht], logName: "xx", xpathOnly: true);


### PR DESCRIPTION
## Summary
- sanitize user values before inserting into XPath filters
- add regression test for escaping special characters

## Testing
- `dotnet build Sources/EventViewerX.sln --no-restore -p:TargetFramework=net8.0`
- `dotnet test Sources/EventViewerX.sln --no-build -f net8.0`


------
https://chatgpt.com/codex/tasks/task_e_68611d497da8832eaeaaa63c27f80937