### PR TITLE
Add Firewall Rule Change event

### DIFF
--- a/Sources/EventViewerX/Rules/Windows/FirewallRuleChange.cs
+++ b/Sources/EventViewerX/Rules/Windows/FirewallRuleChange.cs
@@ -1,0 +1,23 @@
+namespace EventViewerX.Rules.Windows;
+
+/// <summary>
+/// Windows Firewall rule modified
+/// 4947: A change has been made to Windows Firewall exception list. A rule was modified.
+/// </summary>
+public class FirewallRuleChange : EventObjectSlim {
+    public string Computer;
+    public string Action;
+    public string RuleName;
+    public string ProfileChanged;
+    public DateTime When;
+
+    public FirewallRuleChange(EventObject eventObject) : base(eventObject) {
+        _eventObject = eventObject;
+        Type = "FirewallRuleChange";
+        Computer = _eventObject.ComputerName;
+        Action = _eventObject.MessageSubject;
+        RuleName = _eventObject.GetValueFromDataDictionary("RuleName");
+        ProfileChanged = _eventObject.GetValueFromDataDictionary("ProfileChanged");
+        When = _eventObject.TimeCreated;
+    }
+}

--- a/Sources/EventViewerX/SearchEvents.NamedEventsDetails.cs
+++ b/Sources/EventViewerX/SearchEvents.NamedEventsDetails.cs
@@ -166,6 +166,11 @@ namespace EventViewerX {
         AuditPolicyChange,
 
         /// <summary>
+        /// Windows Firewall rule modified
+        /// </summary>
+        FirewallRuleChange,
+
+        /// <summary>
         /// Unexpected system shutdown
         /// </summary>
         OSCrash,
@@ -237,6 +242,7 @@ namespace EventViewerX {
             { NamedEvents.NetworkAccessAuthenticationPolicy, (new List<int> { 6272, 6273 }, "Security") },
             { NamedEvents.CertificateIssued, (new List<int> { 4886, 4887 }, "Security") },
             { NamedEvents.AuditPolicyChange, (new List<int> { 4719 }, "Security") },
+            { NamedEvents.FirewallRuleChange, (new List<int> { 4947 }, "Security") },
             // windows OS
             { NamedEvents.OSCrash, (new List<int> { 6008 }, "System") },
             { NamedEvents.OSStartupShutdownCrash,  (new List<int> { 12, 13, 41, 4608, 4621, 6008 }, "System") },
@@ -352,6 +358,8 @@ namespace EventViewerX {
                             return new CertificateIssued(eventObject);
                         case NamedEvents.AuditPolicyChange:
                             return new AuditPolicyChange(eventObject);
+                        case NamedEvents.FirewallRuleChange:
+                            return new FirewallRuleChange(eventObject);
                         case NamedEvents.OSCrash:
                             return new OSCrash(eventObject);
                         case NamedEvents.OSStartupShutdownCrash:


### PR DESCRIPTION
## Summary
- add `FirewallRuleChange` rule to capture Windows Firewall rule modifications
- register `FirewallRuleChange` in `NamedEvents` and map event ID 4947

## Testing
- `dotnet build Sources/EventViewerX.sln -c Release`
- `pwsh -NoLogo -NoProfile -Command ./PSEventViewer.Tests.ps1` *(fails: Write-Color not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_6861465b3220832e8978a3801d5e495e