### PR TITLE
Add Windows update failure rule

### DIFF
--- a/Sources/EventViewerX/Rules/Windows/WindowsUpdateFailure.cs
+++ b/Sources/EventViewerX/Rules/Windows/WindowsUpdateFailure.cs
@@ -1,0 +1,29 @@
+namespace EventViewerX.Rules.Windows;
+
+/// <summary>
+/// Windows Update installation failure
+/// 20: Installation Failure
+/// </summary>
+public class WindowsUpdateFailure : EventObjectSlim {
+    public string Computer;
+    public string KB;
+    public string Reason;
+    public DateTime When;
+
+    public WindowsUpdateFailure(EventObject eventObject) : base(eventObject) {
+        _eventObject = eventObject;
+        Type = "WindowsUpdateFailure";
+        Computer = _eventObject.ComputerName;
+        var title = _eventObject.GetValueFromDataDictionary("UpdateTitle", "Title");
+        if (string.IsNullOrEmpty(title)) {
+            title = _eventObject.Message;
+        }
+        var kbMatch = System.Text.RegularExpressions.Regex.Match(title ?? string.Empty, @"KB\d{6,7}", System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+        KB = kbMatch.Success ? kbMatch.Value : string.Empty;
+        Reason = _eventObject.GetValueFromDataDictionary("ErrorDescription", "Message");
+        if (string.IsNullOrEmpty(Reason)) {
+            Reason = _eventObject.GetValueFromDataDictionary("ErrorCode", "ResultCode");
+        }
+        When = _eventObject.TimeCreated;
+    }
+}

--- a/Sources/EventViewerX/SearchEvents.NamedEventsDetails.cs
+++ b/Sources/EventViewerX/SearchEvents.NamedEventsDetails.cs
@@ -183,6 +183,10 @@ namespace EventViewerX {
         /// </summary>
         OSTimeChange,
         /// <summary>
+        /// Windows Update installation failure
+        /// </summary>
+        WindowsUpdateFailure,
+        /// <summary>
         /// Group Policy client-side processing events from Application log
         /// </summary>
         ClientGroupPoliciesApplication,
@@ -247,6 +251,7 @@ namespace EventViewerX {
             { NamedEvents.OSCrash, (new List<int> { 6008 }, "System") },
             { NamedEvents.OSStartupShutdownCrash,  (new List<int> { 12, 13, 41, 4608, 4621, 6008 }, "System") },
             { NamedEvents.OSTimeChange, (new List<int> { 4616 }, "Security") },
+            { NamedEvents.WindowsUpdateFailure, (new List<int> { 20 }, "Setup") },
             { NamedEvents.ClientGroupPoliciesApplication, (new List<int> { 4098 }, "Application") },
             { NamedEvents.ClientGroupPoliciesSystem, (new List<int> { 1085 }, "System") },
         };
@@ -366,6 +371,8 @@ namespace EventViewerX {
                             return new OSStartupShutdownCrash(eventObject);
                         case NamedEvents.OSTimeChange:
                             return new OSTimeChange(eventObject);
+                        case NamedEvents.WindowsUpdateFailure:
+                            return new WindowsUpdateFailure(eventObject);
                         case NamedEvents.ClientGroupPoliciesApplication:
                         case NamedEvents.ClientGroupPoliciesSystem:
                             return new ClientGroupPolicies(eventObject);


### PR DESCRIPTION
## Summary
- add `WindowsUpdateFailure` rule for Setup log event ID 20
- extend `NamedEvents` enum and mapping
- support building a `WindowsUpdateFailure` object when matching ID 20

## Testing
- `dotnet build Sources/EventViewerX/EventViewerX.csproj -c Release`
- `pwsh -NoLogo -NoProfile -Command 'Invoke-Pester -Configuration @{Run=@{Exit=$false}}'` *(fails: Invoke-Pester not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861526d0e98832ea0d4257c11324c3d