### PR TITLE
Add BitLocker key change rule

### DIFF
--- a/Sources/EventViewerX/Definitions/Events.cs
+++ b/Sources/EventViewerX/Definitions/Events.cs
@@ -93,3 +93,20 @@ public enum SubStatusCode : uint {
     StatusPasswordExpired = 0xC0000071,
     StatusAccountDisabled = 0xC0000072
 }
+
+public enum BitLockerVolumeType {
+    OperatingSystemVolume = 810,
+    FixedDataVolume = 811,
+    RemovableDataVolume = 812
+}
+
+public enum BitLockerProtectorType {
+    Tpm = 2200,
+    ExternalKey = 2201,
+    NumericalPassword = 2202,
+    TpmPin = 2203,
+    TpmStartupKey = 2204,
+    TpmPinAndStartupKey = 2205,
+    Passphrase = 2206,
+    RecoveryKey = 2207
+}

--- a/Sources/EventViewerX/EventsHelper.cs
+++ b/Sources/EventViewerX/EventsHelper.cs
@@ -100,4 +100,48 @@ internal static class EventsHelper {
         }
         return null;
     }
+
+    /// <summary>
+    /// Translates a string value to a BitLockerProtectorType enum.
+    /// </summary>
+    /// <param name="value">The value to translate.</param>
+    /// <returns>The translated BitLockerProtectorType enum.</returns>
+    public static BitLockerProtectorType? GetBitLockerProtectorType(string value) {
+        if (string.IsNullOrEmpty(value)) {
+            return null;
+        }
+
+        if (value.StartsWith("%%")) {
+            value = value.Trim('%');
+        }
+
+        if (int.TryParse(value, out var number)
+            && Enum.IsDefined(typeof(BitLockerProtectorType), number)) {
+            return (BitLockerProtectorType)number;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Translates a string value to a BitLockerVolumeType enum.
+    /// </summary>
+    /// <param name="value">The value to translate.</param>
+    /// <returns>The translated BitLockerVolumeType enum.</returns>
+    public static BitLockerVolumeType? GetBitLockerVolumeType(string value) {
+        if (string.IsNullOrEmpty(value)) {
+            return null;
+        }
+
+        if (value.StartsWith("%%")) {
+            value = value.Trim('%');
+        }
+
+        if (int.TryParse(value, out var number)
+            && Enum.IsDefined(typeof(BitLockerVolumeType), number)) {
+            return (BitLockerVolumeType)number;
+        }
+
+        return null;
+    }
 }

--- a/Sources/EventViewerX/Rules/Windows/BitLockerKeyChange.cs
+++ b/Sources/EventViewerX/Rules/Windows/BitLockerKeyChange.cs
@@ -1,0 +1,34 @@
+namespace EventViewerX.Rules.Windows;
+
+/// <summary>
+/// BitLocker protection key changed or backed up
+/// 4673: A privileged service was called
+/// 4692: Backup of data protection master key was attempted
+/// </summary>
+public class BitLockerKeyChange : EventObjectSlim {
+    public string Computer;
+    public string Action;
+    public BitLockerVolumeType? Volume;
+    public BitLockerProtectorType? ProtectorType;
+    public string MasterKeyId;
+    public string RecoveryKeyId;
+    public string RecoveryServer;
+    public string Who;
+    public DateTime When;
+
+    public BitLockerKeyChange(EventObject eventObject) : base(eventObject) {
+        _eventObject = eventObject;
+        Type = "BitLockerKeyChange";
+        Computer = _eventObject.ComputerName;
+        Action = _eventObject.MessageSubject;
+        Volume = EventsHelper.GetBitLockerVolumeType(
+            _eventObject.GetValueFromDataDictionary("VolumeName", "Volume"));
+        ProtectorType = EventsHelper.GetBitLockerProtectorType(
+            _eventObject.GetValueFromDataDictionary("ProtectorType", "KeyProtection"));
+        MasterKeyId = _eventObject.GetValueFromDataDictionary("MasterKeyId");
+        RecoveryKeyId = _eventObject.GetValueFromDataDictionary("RecoveryKeyId");
+        RecoveryServer = _eventObject.GetValueFromDataDictionary("RecoveryServer");
+        Who = _eventObject.GetValueFromDataDictionary("SubjectUserName", "SubjectDomainName", "\\", reverseOrder: true);
+        When = _eventObject.TimeCreated;
+    }
+}

--- a/Sources/EventViewerX/SearchEvents.NamedEventsDetails.cs
+++ b/Sources/EventViewerX/SearchEvents.NamedEventsDetails.cs
@@ -171,6 +171,11 @@ namespace EventViewerX {
         FirewallRuleChange,
 
         /// <summary>
+        /// BitLocker protection key changed or backed up
+        /// </summary>
+        BitLockerKeyChange,
+
+        /// <summary>
         /// Unexpected system shutdown
         /// </summary>
         OSCrash,
@@ -247,6 +252,7 @@ namespace EventViewerX {
             { NamedEvents.CertificateIssued, (new List<int> { 4886, 4887 }, "Security") },
             { NamedEvents.AuditPolicyChange, (new List<int> { 4719 }, "Security") },
             { NamedEvents.FirewallRuleChange, (new List<int> { 4947 }, "Security") },
+            { NamedEvents.BitLockerKeyChange, (new List<int> { 4673, 4692 }, "Security") },
             // windows OS
             { NamedEvents.OSCrash, (new List<int> { 6008 }, "System") },
             { NamedEvents.OSStartupShutdownCrash,  (new List<int> { 12, 13, 41, 4608, 4621, 6008 }, "System") },
@@ -365,6 +371,8 @@ namespace EventViewerX {
                             return new AuditPolicyChange(eventObject);
                         case NamedEvents.FirewallRuleChange:
                             return new FirewallRuleChange(eventObject);
+                        case NamedEvents.BitLockerKeyChange:
+                            return new BitLockerKeyChange(eventObject);
                         case NamedEvents.OSCrash:
                             return new OSCrash(eventObject);
                         case NamedEvents.OSStartupShutdownCrash:


### PR DESCRIPTION
## Summary
- add BitLockerKeyChange rule for events 4673 and 4692
- translate BitLocker protector and volume types
- register BitLocker events in named events map

## Testing
- `dotnet build Sources/EventViewerX/EventViewerX.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_686187ebc3a8832e9f3172a8fafedd09