### PR TITLE
Add Kerberos policy change rule

### DIFF
--- a/Sources/EventViewerX/Rules/Kerberos/KerberosPolicyChange.cs
+++ b/Sources/EventViewerX/Rules/Kerberos/KerberosPolicyChange.cs
@@ -1,0 +1,59 @@
+namespace EventViewerX.Rules.Kerberos;
+
+public class KerberosPolicyChange : EventObjectSlim
+{
+    public string Computer;
+    public string Who;
+    public string PolicyChanges;
+    public double? KerProxyMinutes;
+    public double? KerMaxRDays;
+    public double? KerMaxTHours;
+    public double? KerMinTMinutes;
+    public bool? EnforceUserLogonRestrictions;
+    public DateTime When;
+
+    public KerberosPolicyChange(EventObject eventObject) : base(eventObject)
+    {
+        _eventObject = eventObject;
+        Type = "KerberosPolicyChange";
+        Computer = _eventObject.ComputerName;
+        Who = _eventObject.GetValueFromDataDictionary("SubjectUserName", "SubjectDomainName", "\\", reverseOrder: true);
+        PolicyChanges = _eventObject.GetValueFromDataDictionary("KerberosPolicyChange");
+        When = _eventObject.TimeCreated;
+
+        if (!string.IsNullOrEmpty(PolicyChanges) && PolicyChanges != "--")
+        {
+            foreach (var part in PolicyChanges.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries))
+            {
+                var section = part.Trim();
+                if (section.Length == 0) continue;
+                var kv = section.Split(new[] { ':' }, 2);
+                if (kv.Length != 2) continue;
+                var name = kv[0].Trim();
+                var valuePart = kv[1];
+                var hexMatch = System.Text.RegularExpressions.Regex.Match(valuePart, "0x([0-9A-Fa-f]+)");
+                if (!hexMatch.Success) continue;
+                var newValue = Convert.ToInt64(hexMatch.Groups[1].Value, 16);
+
+                switch (name)
+                {
+                    case "KerProxy":
+                        KerProxyMinutes = newValue / 600000000d;
+                        break;
+                    case "KerMaxR":
+                        KerMaxRDays = newValue / 864000000000d;
+                        break;
+                    case "KerMaxT":
+                        KerMaxTHours = newValue / 36000000000d;
+                        break;
+                    case "KerMinT":
+                        KerMinTMinutes = newValue / 600000000d;
+                        break;
+                    case "KerOpts":
+                        EnforceUserLogonRestrictions = newValue == 0x80;
+                        break;
+                }
+            }
+        }
+    }
+}

--- a/Sources/EventViewerX/SearchEvents.NamedEventsDetails.cs
+++ b/Sources/EventViewerX/SearchEvents.NamedEventsDetails.cs
@@ -124,6 +124,10 @@ namespace EventViewerX {
         /// </summary>
         KerberosTicketFailure,
         /// <summary>
+        /// Kerberos policy changed
+        /// </summary>
+        KerberosPolicyChange,
+        /// <summary>
         /// Organizational unit created, deleted or moved
         /// </summary>
         ADOrganizationalUnitChangeDetailed,
@@ -236,6 +240,7 @@ namespace EventViewerX {
             { NamedEvents.ADUserUnlocked, ([4767], "Security") },
             { NamedEvents.KerberosServiceTicket, (new List<int> { 4769, 4770 }, "Security") },
             { NamedEvents.KerberosTicketFailure, (new List<int> { 4771, 4772 }, "Security") },
+            { NamedEvents.KerberosPolicyChange, (new List<int> { 4713 }, "Security") },
             // other based events
             { NamedEvents.ADOtherChangeDetailed, (new List<int> { 5136, 5137, 5139, 5141 }, "Security") },
             // ldap events
@@ -341,6 +346,8 @@ namespace EventViewerX {
                             return new KerberosServiceTicket(eventObject);
                         case NamedEvents.KerberosTicketFailure:
                             return new KerberosTicketFailure(eventObject);
+                        case NamedEvents.KerberosPolicyChange:
+                            return new KerberosPolicyChange(eventObject);
                         // organizational unit and other events
                         case NamedEvents.ADOrganizationalUnitChangeDetailed:
                             if (objectClass == "organizationalUnit" && eventObject.Data["AttributeLDAPDisplayName"] != "qPLik") {


### PR DESCRIPTION
## Summary
- add `KerberosPolicyChange` rule for security event 4713
- translate ticket lifetime values
- map `KerberosPolicyChange` in `NamedEvents` and event ID lookups

## Testing
- `dotnet build Sources/EventViewerX.sln -c Release`
- `dotnet test Sources/EventViewerX.sln`
- `pwsh -NoLogo -NoProfile -Command ./PSEventViewer.Tests.ps1` *(fails: Write-Color, PSSharedGoods, Invoke-Pester not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861907c04f8832eb6bb60b52d4e21d2