### PR TITLE
Fix build by checking for PowerShell DLLs

### DIFF
--- a/Sources/PSEventViewer/PSEventViewer.csproj
+++ b/Sources/PSEventViewer/PSEventViewer.csproj
@@ -43,8 +43,10 @@
 
     <!-- We need to remove PowerShell conflicting libraries as it will break output -->
     <Target Name="RemoveFilesAfterBuild" AfterTargets="Build">
-        <Delete Files="$(OutDir)System.Management.Automation.dll" />
-        <Delete Files="$(OutDir)System.Management.dll" />
+        <Delete Files="$(OutDir)System.Management.Automation.dll"
+                Condition="Exists('$(OutDir)System.Management.Automation.dll')" />
+        <Delete Files="$(OutDir)System.Management.dll"
+                Condition="Exists('$(OutDir)System.Management.Automation.dll')" />
     </Target>
 
     <PropertyGroup>


### PR DESCRIPTION
## Summary
- avoid deleting PowerShell assemblies when they aren't present

## Testing
- `dotnet build Sources/EventViewerX.sln -c Release`
- `pwsh ./PSEventViewer.Tests.ps1` *(fails: Install-Package: No match was found for 'Pester')*

------
https://chatgpt.com/codex/tasks/task_e_686194294dec832e81f1d0e9357c58ff