### PR TITLE
Implement async enumerable for QueryLogsParallel

### DIFF
--- a/Sources/EventViewerX.Examples/Examples.FindBasic.cs
+++ b/Sources/EventViewerX.Examples/Examples.FindBasic.cs
@@ -3,9 +3,9 @@ using EventViewerX.Rules.Windows;
 
 namespace EventViewerX.Examples {
     internal partial class Examples {
-        public static void FindEventsTargetedBasic() {
+        public static async Task FindEventsTargetedBasic() {
 
-            foreach (var foundObject in SearchEvents.FindEventsByNamedEvents([NamedEvents.OSCrash, NamedEvents.OSStartupShutdownCrash])) {
+            await foreach (var foundObject in SearchEvents.FindEventsByNamedEvents([NamedEvents.OSCrash, NamedEvents.OSStartupShutdownCrash])) {
 
                 Console.WriteLine("Event ID: {0}", foundObject.EventID + ", " + foundObject.Type + " " + foundObject.GatheredFrom);
                 Console.WriteLine("Type: " + foundObject.Type + ", " + foundObject.EventID + " " + foundObject.EventID + " " + foundObject.GatheredFrom);
@@ -24,7 +24,7 @@ namespace EventViewerX.Examples {
             }
         }
 
-        public static void FindEventsTargetedPerType() {
+        public static async Task FindEventsTargetedPerType() {
             List<string> MachineName = new List<string> { "AD1", "AD2", "AD0" };
 
             // Initialize the logger
@@ -34,7 +34,7 @@ namespace EventViewerX.Examples {
             eventSearching.Verbose = true;
 
             List<NamedEvents> Type = new List<NamedEvents> { NamedEvents.ADLdapBindingDetails, NamedEvents.ADLdapBindingSummary };
-            foreach (var foundObject in SearchEvents.FindEventsByNamedEvents(Type, MachineName)) {
+            await foreach (var foundObject in SearchEvents.FindEventsByNamedEvents(Type, MachineName)) {
                 // Check if the foundObject is of type ADComputerChangeDetailed
 
                 // Console.WriteLine("Event ID: {0}", foundObject.EventID + ", " + foundObject.Type + " " + foundObject.GatheredFrom);

--- a/Sources/EventViewerX.Examples/Examples.QueryParallelSpeed.cs
+++ b/Sources/EventViewerX.Examples/Examples.QueryParallelSpeed.cs
@@ -3,7 +3,7 @@
 namespace EventViewerX.Examples {
     internal partial class Examples {
 
-        public static void QueryParallelSpeed() {
+        public static async Task QueryParallelSpeed() {
             var eventSearching = new SearchEvents {
                 Verbose = true,
                 Warning = true,
@@ -22,7 +22,7 @@ namespace EventViewerX.Examples {
             });
         }
 
-        public static void QueryParallelCompare() {
+        public static async Task QueryParallelCompare() {
             var eventSearching = new SearchEvents {
                 Verbose = true,
                 Warning = true,
@@ -45,7 +45,7 @@ namespace EventViewerX.Examples {
 
             stopwatch.Restart();
             int eventCount2 = 0;
-            foreach (var eventObject in SearchEvents.QueryLogsParallel("Security", eventIds, machineNames)) {
+            await foreach (var eventObject in SearchEvents.QueryLogsParallel("Security", eventIds, machineNames)) {
                 eventCount2++;
             }
             stopwatch.Stop();

--- a/Sources/EventViewerX.Examples/Examples.QueryParallelWithCount.cs
+++ b/Sources/EventViewerX.Examples/Examples.QueryParallelWithCount.cs
@@ -1,7 +1,7 @@
 ﻿namespace EventViewerX.Examples {
     internal partial class Examples {
 
-        public static void QueryParallelWithCount() {
+        public static async Task QueryParallelWithCount() {
             var eventSearching = new SearchEvents {
                 Verbose = true,
                 Warning = true,
@@ -16,7 +16,7 @@
             // Initialize a dictionary to keep track of the number of events per server
             var eventCounts = new Dictionary<string, int>();
 
-            foreach (var eventObject in SearchEvents.QueryLogsParallel("Security", eventIds, machineNames)) {
+            await foreach (var eventObject in SearchEvents.QueryLogsParallel("Security", eventIds, machineNames)) {
                 // If the server is not yet in the dictionary, add it with a count of 1
                 if (!eventCounts.ContainsKey(eventObject.ComputerName)) {
                     eventCounts[eventObject.ComputerName] = 1;

--- a/Sources/EventViewerX/SearchEvents.QueryNamedEvents.cs
+++ b/Sources/EventViewerX/SearchEvents.QueryNamedEvents.cs
@@ -3,10 +3,11 @@ using System.Collections.Generic;
 using System.Linq;
 
 using System.Threading;
+using System.Runtime.CompilerServices;
 namespace EventViewerX {
     public partial class SearchEvents : Settings {
 
-        public static IEnumerable<EventObjectSlim> FindEventsByNamedEvents(List<NamedEvents> typeEventsList, List<string> machineNames = null, DateTime? startTime = null, DateTime? endTime = null, TimePeriod? timePeriod = null, int maxThreads = 8, int maxEvents = 0, CancellationToken cancellationToken = default) {
+        public static async IAsyncEnumerable<EventObjectSlim> FindEventsByNamedEvents(List<NamedEvents> typeEventsList, List<string> machineNames = null, DateTime? startTime = null, DateTime? endTime = null, TimePeriod? timePeriod = null, int maxThreads = 8, int maxEvents = 0, [EnumeratorCancellation] CancellationToken cancellationToken = default) {
             // Create a dictionary to store unique event IDs and log names
             var eventInfoDict = new Dictionary<string, HashSet<int>>();
 
@@ -32,9 +33,8 @@ namespace EventViewerX {
                 var logName = kvp.Key;
                 var eventIds = kvp.Value.ToList();
 
-                foreach (var foundEvent in SearchEvents.QueryLogsParallel(logName, eventIds, machineNames, startTime: startTime, endTime: endTime, timePeriod: timePeriod, maxThreads: maxThreads, maxEvents: maxEvents, cancellationToken: cancellationToken)) {
+                await foreach (var foundEvent in SearchEvents.QueryLogsParallel(logName, eventIds, machineNames, startTime: startTime, endTime: endTime, timePeriod: timePeriod, maxThreads: maxThreads, maxEvents: maxEvents, cancellationToken: cancellationToken)) {
                     _logger.WriteDebug($"Found event: {foundEvent.Id} {foundEvent.LogName} {foundEvent.ComputerName}");
-                    // yield return BuildTargetEvents(foundEvent, typeEventsList);
                     var targetEvent = BuildTargetEvents(foundEvent, typeEventsList);
                     if (targetEvent != null) {
                         yield return targetEvent;

--- a/Sources/PSEventViewer/CmdletGetEVXEvent.cs
+++ b/Sources/PSEventViewer/CmdletGetEVXEvent.cs
@@ -203,12 +203,12 @@ public sealed class CmdletGetEVXEvent : AsyncPSCmdlet {
         var internalLogger = new InternalLogger(false);
         var internalLoggerPowerShell = new InternalLoggerPowerShell(internalLogger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
         var searchEvents = new SearchEvents(internalLogger);
-        return Task.CompletedTask;
+        return;
     }
     /// <summary>
     /// Executes the event query based on provided parameters.
     /// </summary>
-    protected override Task ProcessRecordAsync() {
+    protected override async Task ProcessRecordAsync() {
         var results = AsArray ? new List<object>() : null;
 
         if (ParameterSetName == "ListLog") {
@@ -248,7 +248,7 @@ public sealed class CmdletGetEVXEvent : AsyncPSCmdlet {
             if (Type != null) {
                 // let's find the events prepared for search
                 List<NamedEvents> typeList = Type.ToList();
-                foreach (var eventObject in SearchEvents.FindEventsByNamedEvents(typeList, MachineName, StartTime, EndTime, TimePeriod, maxThreads: NumberOfThreads, maxEvents: MaxEvents, cancellationToken: CancelToken)) {
+                await foreach (var eventObject in SearchEvents.FindEventsByNamedEvents(typeList, MachineName, StartTime, EndTime, TimePeriod, maxThreads: NumberOfThreads, maxEvents: MaxEvents, cancellationToken: CancelToken)) {
                     if (!MessageMatches(eventObject._eventObject)) {
                         continue;
                     }
@@ -288,7 +288,7 @@ public sealed class CmdletGetEVXEvent : AsyncPSCmdlet {
                             }
                         }
                     } else if (ParallelOption == ParallelOption.Parallel) {
-                        foreach (var eventObject in SearchEvents.QueryLogsParallel(LogName, EventId, MachineName, ProviderName, Keywords, Level, StartTime, EndTime, UserId, MaxEvents, NumberOfThreads, EventRecordId, TimePeriod, CancelToken)) {
+                        await foreach (var eventObject in SearchEvents.QueryLogsParallel(LogName, EventId, MachineName, ProviderName, Keywords, Level, StartTime, EndTime, UserId, MaxEvents, NumberOfThreads, EventRecordId, TimePeriod, CancelToken)) {
                             if (!MessageMatches(eventObject)) {
                                 continue;
                             }
@@ -328,7 +328,7 @@ public sealed class CmdletGetEVXEvent : AsyncPSCmdlet {
                             }
                         }
                     } else if (ParallelOption == ParallelOption.Parallel) {
-                        foreach (var eventObject in SearchEvents.QueryLogsParallel(LogName, EventId, MachineName, ProviderName, Keywords, Level, StartTime, EndTime, UserId, MaxEvents, NumberOfThreads, EventRecordId, TimePeriod, CancelToken)) {
+                        await foreach (var eventObject in SearchEvents.QueryLogsParallel(LogName, EventId, MachineName, ProviderName, Keywords, Level, StartTime, EndTime, UserId, MaxEvents, NumberOfThreads, EventRecordId, TimePeriod, CancelToken)) {
                             if (!MessageMatches(eventObject)) {
                                 continue;
                             }
@@ -348,7 +348,7 @@ public sealed class CmdletGetEVXEvent : AsyncPSCmdlet {
             WriteObject(results.ToArray(), false);
         }
 
-        return Task.CompletedTask;
+        return;
     }
     /// <summary>
     /// Returns the expanded object - it takes the EventObject and returns the PSObject with the properties expanded from the Data property.


### PR DESCRIPTION
## Summary
- refactor `QueryLogsParallel` to return `IAsyncEnumerable` and await tasks
- adjust `QueryNamedEvents` and cmdlet to consume async enumeration
- update example projects for new async API

## Testing
- `dotnet build Sources/EventViewerX.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6861941cb4dc832eb74f6a20ea20d7d4