### PR TITLE
Add DeviceRecognized event handling

### DIFF
--- a/Sources/EventViewerX/Rules/Windows/DeviceRecognized.cs
+++ b/Sources/EventViewerX/Rules/Windows/DeviceRecognized.cs
@@ -1,0 +1,37 @@
+namespace EventViewerX.Rules.Windows;
+
+/// <summary>
+/// External device recognized by the system
+/// 6416: A new external device was recognized by the System.
+/// </summary>
+public class DeviceRecognized : EventObjectSlim {
+    public string Computer;
+    public string DeviceId;
+    public string DeviceName;
+    public string ClassId;
+    public string ClassName;
+    public string VendorIds;
+    public string CompatibleIds;
+    public string LocationInformation;
+    public string DeviceType;
+    public string Vendor;
+    public string Who;
+    public DateTime When;
+
+    public DeviceRecognized(EventObject eventObject) : base(eventObject) {
+        _eventObject = eventObject;
+        Type = "DeviceRecognized";
+        Computer = _eventObject.ComputerName;
+        DeviceId = _eventObject.GetValueFromDataDictionary("DeviceId");
+        DeviceName = _eventObject.GetValueFromDataDictionary("DeviceDescription", "DeviceName");
+        ClassId = _eventObject.GetValueFromDataDictionary("ClassId");
+        ClassName = _eventObject.GetValueFromDataDictionary("ClassName");
+        VendorIds = _eventObject.GetValueFromDataDictionary("VendorIds");
+        CompatibleIds = _eventObject.GetValueFromDataDictionary("CompatibleIds");
+        LocationInformation = _eventObject.GetValueFromDataDictionary("LocationInformation");
+        DeviceType = EventsHelper.TranslateDeviceType(ClassName);
+        Vendor = EventsHelper.TranslateVendor(VendorIds);
+        Who = _eventObject.GetValueFromDataDictionary("SubjectUserName", "SubjectDomainName", "\\", reverseOrder: true);
+        When = _eventObject.TimeCreated;
+    }
+}

--- a/Sources/EventViewerX/SearchEvents.NamedEventsDetails.cs
+++ b/Sources/EventViewerX/SearchEvents.NamedEventsDetails.cs
@@ -180,6 +180,11 @@ namespace EventViewerX {
         BitLockerKeyChange,
 
         /// <summary>
+        /// External device recognized by the system
+        /// </summary>
+        DeviceRecognized,
+
+        /// <summary>
         /// Unexpected system shutdown
         /// </summary>
         OSCrash,
@@ -258,6 +263,7 @@ namespace EventViewerX {
             { NamedEvents.AuditPolicyChange, (new List<int> { 4719 }, "Security") },
             { NamedEvents.FirewallRuleChange, (new List<int> { 4947 }, "Security") },
             { NamedEvents.BitLockerKeyChange, (new List<int> { 4673, 4692 }, "Security") },
+            { NamedEvents.DeviceRecognized, (new List<int> { 6416 }, "Security") },
             // windows OS
             { NamedEvents.OSCrash, (new List<int> { 6008 }, "System") },
             { NamedEvents.OSStartupShutdownCrash,  (new List<int> { 12, 13, 41, 4608, 4621, 6008 }, "System") },
@@ -380,6 +386,8 @@ namespace EventViewerX {
                             return new FirewallRuleChange(eventObject);
                         case NamedEvents.BitLockerKeyChange:
                             return new BitLockerKeyChange(eventObject);
+                        case NamedEvents.DeviceRecognized:
+                            return new DeviceRecognized(eventObject);
                         case NamedEvents.OSCrash:
                             return new OSCrash(eventObject);
                         case NamedEvents.OSStartupShutdownCrash:


### PR DESCRIPTION
## Summary
- handle event ID 6416 with new `DeviceRecognized` rule
- translate device type and vendor IDs
- register `DeviceRecognized` in named event maps

## Testing
- `dotnet build Sources/EventViewerX.sln -c Release`
- `pwsh -NoLogo -NoProfile -Command ./PSEventViewer.Tests.ps1` *(fails: Write-Color cmdlet missing)*

------
https://chatgpt.com/codex/tasks/task_e_686235e6f06c832ebf2efc0d475fb966