### PR TITLE
Add Windows scheduled task delete rule

### DIFF
--- a/Sources/EventViewerX/Rules/Windows/ScheduledTaskDeleted.cs
+++ b/Sources/EventViewerX/Rules/Windows/ScheduledTaskDeleted.cs
@@ -1,0 +1,21 @@
+namespace EventViewerX.Rules.Windows;
+
+/// <summary>
+/// Scheduled task deleted
+/// 4699: A scheduled task was deleted
+/// </summary>
+public class ScheduledTaskDeleted : EventObjectSlim {
+    public string Computer;
+    public string TaskName;
+    public string Who;
+    public DateTime When;
+
+    public ScheduledTaskDeleted(EventObject eventObject) : base(eventObject) {
+        _eventObject = eventObject;
+        Type = "ScheduledTaskDeleted";
+        Computer = _eventObject.ComputerName;
+        TaskName = _eventObject.GetValueFromDataDictionary("TaskName");
+        Who = _eventObject.GetValueFromDataDictionary("SubjectUserName", "SubjectDomainName", "\\", reverseOrder: true);
+        When = _eventObject.TimeCreated;
+    }
+}

--- a/Sources/EventViewerX/SearchEvents.NamedEventsDetails.cs
+++ b/Sources/EventViewerX/SearchEvents.NamedEventsDetails.cs
@@ -185,6 +185,11 @@ namespace EventViewerX {
         DeviceRecognized,
 
         /// <summary>
+        /// Scheduled task deleted
+        /// </summary>
+        ScheduledTaskDeleted,
+
+        /// <summary>
         /// Unexpected system shutdown
         /// </summary>
         OSCrash,
@@ -264,6 +269,7 @@ namespace EventViewerX {
             { NamedEvents.FirewallRuleChange, (new List<int> { 4947 }, "Security") },
             { NamedEvents.BitLockerKeyChange, (new List<int> { 4673, 4692 }, "Security") },
             { NamedEvents.DeviceRecognized, (new List<int> { 6416 }, "Security") },
+            { NamedEvents.ScheduledTaskDeleted, (new List<int> { 4699 }, "Security") },
             // windows OS
             { NamedEvents.OSCrash, (new List<int> { 6008 }, "System") },
             { NamedEvents.OSStartupShutdownCrash,  (new List<int> { 12, 13, 41, 4608, 4621, 6008 }, "System") },
@@ -388,6 +394,8 @@ namespace EventViewerX {
                             return new BitLockerKeyChange(eventObject);
                         case NamedEvents.DeviceRecognized:
                             return new DeviceRecognized(eventObject);
+                        case NamedEvents.ScheduledTaskDeleted:
+                            return new ScheduledTaskDeleted(eventObject);
                         case NamedEvents.OSCrash:
                             return new OSCrash(eventObject);
                         case NamedEvents.OSStartupShutdownCrash:


### PR DESCRIPTION
## Summary
- add `ScheduledTaskDeleted` rule for event ID 4699
- capture task name and deleting user
- expose rule through `NamedEvents` mapping

## Testing
- `dotnet build Sources/EventViewerX.sln -c Release`
- `dotnet test Sources/EventViewerX.sln --no-build` *(fails: invalid argument)*

------
https://chatgpt.com/codex/tasks/task_e_68624f2c6324832eb0862183648e9a0d