### PR TITLE
Add rule for event 4660

### DIFF
--- a/Sources/EventViewerX/Rules/Windows/ObjectDeletion.cs
+++ b/Sources/EventViewerX/Rules/Windows/ObjectDeletion.cs
@@ -1,0 +1,21 @@
+namespace EventViewerX.Rules.Windows;
+
+/// <summary>
+/// Object deleted
+/// 4660: An object was deleted
+/// </summary>
+public class ObjectDeletion : EventObjectSlim {
+    public string Computer;
+    public string Path;
+    public string Who;
+    public DateTime When;
+
+    public ObjectDeletion(EventObject eventObject) : base(eventObject) {
+        _eventObject = eventObject;
+        Type = "ObjectDeletion";
+        Computer = _eventObject.ComputerName;
+        Path = _eventObject.GetValueFromDataDictionary("ObjectName");
+        Who = _eventObject.GetValueFromDataDictionary("SubjectUserName", "SubjectDomainName", "\\", reverseOrder: true);
+        When = _eventObject.TimeCreated;
+    }
+}

--- a/Sources/EventViewerX/SearchEvents.NamedEventsDetails.cs
+++ b/Sources/EventViewerX/SearchEvents.NamedEventsDetails.cs
@@ -185,6 +185,11 @@ namespace EventViewerX {
         DeviceRecognized,
 
         /// <summary>
+        /// Object deleted
+        /// </summary>
+        ObjectDeletion,
+
+        /// <summary>
         /// Scheduled task deleted
         /// </summary>
         ScheduledTaskDeleted,
@@ -269,6 +274,7 @@ namespace EventViewerX {
             { NamedEvents.FirewallRuleChange, (new List<int> { 4947 }, "Security") },
             { NamedEvents.BitLockerKeyChange, (new List<int> { 4673, 4692 }, "Security") },
             { NamedEvents.DeviceRecognized, (new List<int> { 6416 }, "Security") },
+            { NamedEvents.ObjectDeletion, (new List<int> { 4660 }, "Security") },
             { NamedEvents.ScheduledTaskDeleted, (new List<int> { 4699 }, "Security") },
             // windows OS
             { NamedEvents.OSCrash, (new List<int> { 6008 }, "System") },
@@ -394,6 +400,8 @@ namespace EventViewerX {
                             return new BitLockerKeyChange(eventObject);
                         case NamedEvents.DeviceRecognized:
                             return new DeviceRecognized(eventObject);
+                        case NamedEvents.ObjectDeletion:
+                            return new ObjectDeletion(eventObject);
                         case NamedEvents.ScheduledTaskDeleted:
                             return new ScheduledTaskDeleted(eventObject);
                         case NamedEvents.OSCrash:


### PR DESCRIPTION
## Summary
- add `ObjectDeletion` rule for event ID 4660
- translate path and deleting user
- register `ObjectDeletion` in `NamedEvents` and map ID 4660

## Testing
- `dotnet build Sources/EventViewerX/EventViewerX.csproj -c Release`
- `pwsh -NoLogo -NoProfile -File PSEventViewer.Tests.ps1` *(fails: Write-Color not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_6862e42ae6e0832e9b66c6036a0b5763