### PR TITLE
Add ScheduledTaskCreated rule for event ID 4698

### DIFF
--- a/Sources/EventViewerX/Rules/Windows/ScheduledTaskCreated.cs
+++ b/Sources/EventViewerX/Rules/Windows/ScheduledTaskCreated.cs
@@ -1,0 +1,34 @@
+namespace EventViewerX.Rules.Windows;
+
+/// <summary>
+/// Scheduled task created
+/// 4698: A scheduled task was created
+/// </summary>
+public class ScheduledTaskCreated : EventObjectSlim {
+    public string Computer;
+    public string TaskName;
+    public string Author;
+    public DateTime? Created;
+    public DateTime When;
+
+    public ScheduledTaskCreated(EventObject eventObject) : base(eventObject) {
+        _eventObject = eventObject;
+        Type = "ScheduledTaskCreated";
+        Computer = _eventObject.ComputerName;
+        TaskName = _eventObject.GetValueFromDataDictionary("TaskName");
+        var taskContent = _eventObject.GetValueFromDataDictionary("TaskContent");
+        if (!string.IsNullOrEmpty(taskContent)) {
+            try {
+                var xml = System.Xml.Linq.XDocument.Parse(taskContent);
+                Author = xml.Root?.Element("RegistrationInfo")?.Element("Author")?.Value ?? string.Empty;
+                var createdStr = xml.Root?.Element("RegistrationInfo")?.Element("Date")?.Value;
+                if (DateTime.TryParse(createdStr, out var dt)) {
+                    Created = dt;
+                }
+            } catch {
+                // ignore malformed XML
+            }
+        }
+        When = _eventObject.TimeCreated;
+    }
+}

--- a/Sources/EventViewerX/SearchEvents.NamedEventsDetails.cs
+++ b/Sources/EventViewerX/SearchEvents.NamedEventsDetails.cs
@@ -193,6 +193,10 @@ namespace EventViewerX {
         /// Scheduled task deleted
         /// </summary>
         ScheduledTaskDeleted,
+        /// <summary>
+        /// Scheduled task created
+        /// </summary>
+        ScheduledTaskCreated,
 
         /// <summary>
         /// Unexpected system shutdown
@@ -276,6 +280,7 @@ namespace EventViewerX {
             { NamedEvents.DeviceRecognized, (new List<int> { 6416 }, "Security") },
             { NamedEvents.ObjectDeletion, (new List<int> { 4660 }, "Security") },
             { NamedEvents.ScheduledTaskDeleted, (new List<int> { 4699 }, "Security") },
+            { NamedEvents.ScheduledTaskCreated, (new List<int> { 4698 }, "Security") },
             // windows OS
             { NamedEvents.OSCrash, (new List<int> { 6008 }, "System") },
             { NamedEvents.OSStartupShutdownCrash,  (new List<int> { 12, 13, 41, 4608, 4621, 6008 }, "System") },
@@ -404,6 +409,8 @@ namespace EventViewerX {
                             return new ObjectDeletion(eventObject);
                         case NamedEvents.ScheduledTaskDeleted:
                             return new ScheduledTaskDeleted(eventObject);
+                        case NamedEvents.ScheduledTaskCreated:
+                            return new ScheduledTaskCreated(eventObject);
                         case NamedEvents.OSCrash:
                             return new OSCrash(eventObject);
                         case NamedEvents.OSStartupShutdownCrash:


### PR DESCRIPTION
## Summary
- add `ScheduledTaskCreated` rule handling Security event ID 4698
- parse scheduled task author and creation time from XML content
- register the new rule in `eventIdsMap`

## Testing
- `dotnet build Sources/EventViewerX.sln -c Release`
- `pwsh -c "./PSEventViewer.Tests.ps1"` *(fails: Install-Package: No match was found for the specified search criteria and module name)*

------
https://chatgpt.com/codex/tasks/task_e_6862e8c4a128832ea5c7f7738e8924a9