### PR TITLE
Add KerberosTGTRequest support

### DIFF
--- a/Sources/EventViewerX/Rules/Kerberos/KerberosTGTRequest.cs
+++ b/Sources/EventViewerX/Rules/Kerberos/KerberosTGTRequest.cs
@@ -1,0 +1,42 @@
+namespace EventViewerX.Rules.Kerberos;
+
+public class KerberosTGTRequest : EventObjectSlim
+{
+    public string Computer;
+    public string Action;
+    public string AccountName;
+    public string IpAddress;
+    public string IpPort;
+    public TicketOptions? TicketOptions;
+    public Status? Status;
+    public TicketEncryptionType? EncryptionType;
+    public PreAuthType? PreAuthType;
+    public bool WeakEncryptionAlgorithm;
+    public DateTime When;
+
+    public KerberosTGTRequest(EventObject eventObject) : base(eventObject)
+    {
+        _eventObject = eventObject;
+        Type = "KerberosTGTRequest";
+        Computer = _eventObject.ComputerName;
+        Action = _eventObject.MessageSubject;
+        AccountName = _eventObject.GetValueFromDataDictionary("TargetUserName", "TargetDomainName", "\\", reverseOrder: true);
+        IpAddress = _eventObject.GetValueFromDataDictionary("IpAddress");
+        IpPort = _eventObject.GetValueFromDataDictionary("IpPort");
+        TicketOptions = EventsHelper.GetTicketOptions(_eventObject.GetValueFromDataDictionary("TicketOptions"));
+        Status = EventsHelper.GetStatus(_eventObject.GetValueFromDataDictionary("Status"));
+        EncryptionType = EventsHelper.GetTicketEncryptionType(_eventObject.GetValueFromDataDictionary("TicketEncryptionType"));
+        PreAuthType = EventsHelper.GetPreAuthType(_eventObject.GetValueFromDataDictionary("PreAuthType"));
+        When = _eventObject.TimeCreated;
+
+        WeakEncryptionAlgorithm = EncryptionType is TicketEncryptionType.DES_CBC_CRC
+            or TicketEncryptionType.DES_CBC_MD5
+            or TicketEncryptionType.RC4_HMAC
+            or TicketEncryptionType.RC4_HMAC_EXP;
+
+        if (IpAddress == "::1")
+        {
+            IpAddress = "Localhost";
+        }
+    }
+}

--- a/Sources/EventViewerX/SearchEvents.NamedEventsDetails.cs
+++ b/Sources/EventViewerX/SearchEvents.NamedEventsDetails.cs
@@ -116,6 +116,11 @@ namespace EventViewerX {
         /// </summary>
         ADUserUnlocked,
         /// <summary>
+        /// Kerberos TGT requests
+        /// </summary>
+        KerberosTGTRequest,
+
+        /// <summary>
         /// Kerberos service ticket requests and renewals
         /// </summary>
         KerberosServiceTicket,
@@ -257,6 +262,7 @@ namespace EventViewerX {
             { NamedEvents.ADUserLogonFailed, ([4625], "Security")},
             { NamedEvents.ADUserLogonKerberos, ([4768], "Security") },
             { NamedEvents.ADUserUnlocked, ([4767], "Security") },
+            { NamedEvents.KerberosTGTRequest, ([4768], "Security") },
             { NamedEvents.KerberosServiceTicket, (new List<int> { 4769, 4770 }, "Security") },
             { NamedEvents.KerberosTicketFailure, (new List<int> { 4771, 4772 }, "Security") },
             { NamedEvents.KerberosPolicyChange, (new List<int> { 4713 }, "Security") },
@@ -365,6 +371,8 @@ namespace EventViewerX {
                             return new ADUserLogonFailed(eventObject);
                         case NamedEvents.ADUserUnlocked:
                             return new ADUserUnlocked(eventObject);
+                        case NamedEvents.KerberosTGTRequest:
+                            return new KerberosTGTRequest(eventObject);
                         case NamedEvents.KerberosServiceTicket:
                             return new KerberosServiceTicket(eventObject);
                         case NamedEvents.KerberosTicketFailure:


### PR DESCRIPTION
## Summary
- add KerberosTGTRequest rule for Event ID 4768
- decode encryption and pre-auth types using enums
- register KerberosTGTRequest named event

## Testing
- `dotnet test Sources/EventViewerX.sln --no-build --verbosity normal`
- `pwsh ./PSEventViewer.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_68643d762554832e8f725a985c7d720d