### PR TITLE
Add tests for GroupPolicyHelpers

### DIFF
--- a/Sources/EventViewerX.Tests/TestGroupPolicyHelpers.cs
+++ b/Sources/EventViewerX.Tests/TestGroupPolicyHelpers.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Reflection;
+using EventViewerX.Helpers.ActiveDirectory;
+using Xunit;
+
+namespace EventViewerX.Tests;
+
+public class TestGroupPolicyHelpers {
+    [Fact]
+    public void QueryByDistinguishedNameReturnsNullOnInvalid() {
+        var result = GroupPolicyHelpers.QueryGroupPolicyByDistinguishedName("CN=NonExisting,DC=example,DC=com");
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void QueryInDomainByDistinguishedNameReturnsNullOnInvalid() {
+        var method = typeof(GroupPolicyHelpers).GetMethod(
+            "QueryGroupPolicyInDomainByDistinguishedName",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(method);
+        var result = method!.Invoke(null, new object?[] { "example.com", "CN=NonExisting,DC=example,DC=com" });
+        Assert.Null(result);
+    }
+}


### PR DESCRIPTION
## Summary
- add new unit tests covering GroupPolicyHelpers

## Testing
- `dotnet test Sources/EventViewerX.Tests/EventViewerX.Tests.csproj --no-build`


------
https://chatgpt.com/codex/tasks/task_e_686443b16a9c832e9008042453faf668