### PR TITLE
Fix EventLogReader null query handling

### DIFF
--- a/Sources/EventViewerX/SearchEvents.QueryLog.cs
+++ b/Sources/EventViewerX/SearchEvents.QueryLog.cs
@@ -24,6 +24,11 @@ public partial class SearchEvents : Settings {
     /// <param name="machineName">Name of the machine.</param>
     /// <returns></returns>
     private static EventLogReader CreateEventLogReader(EventLogQuery query, string machineName) {
+        if (query == null) {
+            _logger.WriteWarning($"An error occurred on {machineName} while creating the event log reader: Query cannot be null.");
+            return null;
+        }
+
         try {
             return new EventLogReader(query);
         } catch (EventLogException ex) {


### PR DESCRIPTION
## Summary
- guard `CreateEventLogReader` against null queries

## Testing
- `dotnet build Sources/EventViewerX/EventViewerX.csproj --no-restore -c Release`
- `dotnet build Sources/PSEventViewer/PSEventViewer.csproj --no-restore -c Release`
- `dotnet test Sources/EventViewerX.Tests/EventViewerX.Tests.csproj --no-build --verbosity normal` *(fails: VSTestTask returned false)*

------
https://chatgpt.com/codex/tasks/task_e_686443f0a3a8832ea9dacd6c026b2f4c