### PR TITLE
Implement IDisposable for EventWatcher

### DIFF
--- a/Sources/EventViewerX.Examples/Examples.EventWatchingBasic.cs
+++ b/Sources/EventViewerX.Examples/Examples.EventWatchingBasic.cs
@@ -2,7 +2,7 @@
     internal partial class Examples {
 
         public static void EventWatchingBasic() {
-            WatchEvents c1 = new WatchEvents {
+            using var c1 = new WatchEvents {
                 Warning = true,
                 Verbose = true
             };


### PR DESCRIPTION
## Summary
- enable proper cleanup of `EventLogWatcher` through a new `Dispose` method
- update example to dispose the watcher

## Testing
- `dotnet restore Sources/EventViewerX.sln`
- `dotnet build Sources/EventViewerX.sln --no-restore`
- `dotnet test Sources/EventViewerX.sln --no-build`


------
https://chatgpt.com/codex/tasks/task_e_686443e6080c832eabb73fb6dda89e4f