### PR TITLE
Add ADUserPrivilegeUse for event ID 4672

### DIFF
--- a/Sources/EventViewerX/EventsHelper.cs
+++ b/Sources/EventViewerX/EventsHelper.cs
@@ -183,6 +183,63 @@ internal static class EventsHelper {
         { "0BDA", "Realtek" }
     };
 
+    private static readonly Dictionary<string, string> PrivilegeLookup = new() {
+        { "SeTrustedCredManAccessPrivilege", "Access Credential Manager as a trusted caller" },
+        { "SeNetworkLogonRight", "Access this computer from the network" },
+        { "SeTcbPrivilege", "Act as part of the operating system" },
+        { "SeMachineAccountPrivilege", "Add workstations to domain" },
+        { "SeIncreaseQuotaPrivilege", "Adjust memory quotas for a process" },
+        { "SeInteractiveLogonRight", "Allow log on locally" },
+        { "SeRemoteInteractiveLogonRight", "Allow log on through Remote Desktop Services" },
+        { "SeBackupPrivilege", "Back up files and directories" },
+        { "SeChangeNotifyPrivilege", "Bypass traverse checking" },
+        { "SeSystemtimePrivilege", "Change the system time" },
+        { "SeTimeZonePrivilege", "Change the time zone" },
+        { "SeCreatePagefilePrivilege", "Create a pagefile" },
+        { "SeCreateTokenPrivilege", "Create a token object" },
+        { "SeCreateGlobalPrivilege", "Create global objects" },
+        { "SeCreatePermanentPrivilege", "Create permanent shared objects" },
+        { "SeCreateSymbolicLinkPrivilege", "Create symbolic links" },
+        { "SeDebugPrivilege", "Debug programs" },
+        { "SeDenyNetworkLogonRight", "Deny access to this computer from the network" },
+        { "SeDenyBatchLogonRight", "Deny log on as a batch job" },
+        { "SeDenyServiceLogonRight", "Deny log on as a service" },
+        { "SeDenyInteractiveLogonRight", "Deny log on locally" },
+        { "SeDenyRemoteInteractiveLogonRight", "Deny log on through Remote Desktop Services" },
+        { "SeEnableDelegationPrivilege", "Enable computer and user accounts to be trusted for delegation" },
+        { "SeRemoteShutdownPrivilege", "Force shutdown from a remote system" },
+        { "SeAuditPrivilege", "Generate security audits" },
+        { "SeImpersonatePrivilege", "Impersonate a client after authentication" },
+        { "SeIncreaseWorkingSetPrivilege", "Increase a process working set" },
+        { "SeIncreaseBasePriorityPrivilege", "Increase scheduling priority" },
+        { "SeLoadDriverPrivilege", "Load and unload device drivers" },
+        { "SeLockMemoryPrivilege", "Lock pages in memory" },
+        { "SeBatchLogonRight", "Log on as a batch job" },
+        { "SeServiceLogonRight", "Log on as a service" },
+        { "SeSecurityPrivilege", "Manage auditing and security log" },
+        { "SeRelabelPrivilege", "Modify an object label" },
+        { "SeSystemEnvironmentPrivilege", "Modify firmware environment values" },
+        { "SeManageVolumePrivilege", "Perform volume maintenance tasks" },
+        { "SeProfileSingleProcessPrivilege", "Profile single process" },
+        { "SeSystemProfilePrivilege", "Profile system performance" },
+        { "SeUndockPrivilege", "Remove computer from docking station" },
+        { "SeAssignPrimaryTokenPrivilege", "Replace a process level token" },
+        { "SeRestorePrivilege", "Restore files and directories" },
+        { "SeShutdownPrivilege", "Shut down the system" },
+        { "SeSyncAgentPrivilege", "Synchronize directory service data" },
+        { "SeTakeOwnershipPrivilege", "Take ownership of files or other objects" }
+    };
+
+    public static string TranslatePrivilege(string privilege) {
+        if (string.IsNullOrEmpty(privilege)) {
+            return string.Empty;
+        }
+
+        return PrivilegeLookup.TryGetValue(privilege, out var friendly)
+            ? friendly
+            : privilege;
+    }
+
     /// <summary>
     /// Attempts to translate hardware vendor identifiers to a friendly name.
     /// </summary>

--- a/Sources/EventViewerX/Rules/ActiveDirectory/Users/ADUserPrivilegeUse.cs
+++ b/Sources/EventViewerX/Rules/ActiveDirectory/Users/ADUserPrivilegeUse.cs
@@ -1,0 +1,34 @@
+namespace EventViewerX.Rules.ActiveDirectory;
+
+/// <summary>
+/// Special privileges assigned to new logon
+/// 4672: Special privileges assigned to new logon
+/// </summary>
+public class ADUserPrivilegeUse : EventObjectSlim {
+    public string Computer;
+    public string Action;
+    public string Who;
+    public DateTime When;
+    public List<string> Privileges;
+    public List<string> PrivilegesTranslated;
+
+    public ADUserPrivilegeUse(EventObject eventObject) : base(eventObject) {
+        _eventObject = eventObject;
+        Type = "ADUserPrivilegeUse";
+
+        Computer = _eventObject.ComputerName;
+        Action = _eventObject.MessageSubject;
+
+        Who = _eventObject.GetValueFromDataDictionary("SubjectUserName", "SubjectDomainName", "\\", reverseOrder: true);
+        When = _eventObject.TimeCreated;
+
+        var privilegeList = _eventObject.GetValueFromDataDictionary("PrivilegeList");
+        if (!string.IsNullOrEmpty(privilegeList)) {
+            Privileges = privilegeList.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries).ToList();
+            PrivilegesTranslated = Privileges.Select(EventsHelper.TranslatePrivilege).ToList();
+        } else {
+            Privileges = new List<string>();
+            PrivilegesTranslated = new List<string>();
+        }
+    }
+}

--- a/Sources/EventViewerX/SearchEvents.NamedEventsDetails.cs
+++ b/Sources/EventViewerX/SearchEvents.NamedEventsDetails.cs
@@ -116,6 +116,10 @@ namespace EventViewerX {
         /// </summary>
         ADUserUnlocked,
         /// <summary>
+        /// Special privileges assigned to new logon
+        /// </summary>
+        ADUserPrivilegeUse,
+        /// <summary>
         /// Kerberos TGT requests
         /// </summary>
         KerberosTGTRequest,
@@ -262,6 +266,7 @@ namespace EventViewerX {
             { NamedEvents.ADUserLogonFailed, ([4625], "Security")},
             { NamedEvents.ADUserLogonKerberos, ([4768], "Security") },
             { NamedEvents.ADUserUnlocked, ([4767], "Security") },
+            { NamedEvents.ADUserPrivilegeUse, ([4672], "Security") },
             { NamedEvents.KerberosTGTRequest, ([4768], "Security") },
             { NamedEvents.KerberosServiceTicket, (new List<int> { 4769, 4770 }, "Security") },
             { NamedEvents.KerberosTicketFailure, (new List<int> { 4771, 4772 }, "Security") },
@@ -371,6 +376,8 @@ namespace EventViewerX {
                             return new ADUserLogonFailed(eventObject);
                         case NamedEvents.ADUserUnlocked:
                             return new ADUserUnlocked(eventObject);
+                        case NamedEvents.ADUserPrivilegeUse:
+                            return new ADUserPrivilegeUse(eventObject);
                         case NamedEvents.KerberosTGTRequest:
                             return new KerberosTGTRequest(eventObject);
                         case NamedEvents.KerberosServiceTicket:


### PR DESCRIPTION
## Summary
- add ADUserPrivilegeUse rule for event 4672
- translate privilege codes to friendly text
- map ADUserPrivilegeUse in named events

## Testing
- `dotnet build Sources/EventViewerX.sln -c Release`
- `dotnet test Sources/EventViewerX.sln`


------
https://chatgpt.com/codex/tasks/task_e_68644b697fd4832e804c36defbd177ea