### PR TITLE
Handle user rights assignment events

### DIFF
--- a/Sources/EventViewerX/Rules/ActiveDirectory/Users/ADUserRightsAssignment.cs
+++ b/Sources/EventViewerX/Rules/ActiveDirectory/Users/ADUserRightsAssignment.cs
@@ -1,0 +1,49 @@
+namespace EventViewerX.Rules.ActiveDirectory;
+
+/// <summary>
+/// A user right was assigned or removed
+/// 4704: A user right was assigned
+/// 4705: A user right was removed
+/// </summary>
+public class ADUserRightsAssignment : EventObjectSlim {
+    public string Computer;
+    public string Action;
+    public string UserAffected;
+    public string Who;
+    public DateTime When;
+    public List<string> Rights;
+    public List<string> RightsTranslated;
+
+    public ADUserRightsAssignment(EventObject eventObject) : base(eventObject) {
+        _eventObject = eventObject;
+        Type = "ADUserRightsAssignment";
+
+        Computer = _eventObject.ComputerName;
+        Action = _eventObject.MessageSubject;
+
+        UserAffected = _eventObject.GetValueFromDataDictionary("TargetUserName", "TargetDomainName", "\\", reverseOrder: true);
+        if (string.IsNullOrEmpty(UserAffected)) {
+            var sid = _eventObject.GetValueFromDataDictionary("TargetSid");
+            if (!string.IsNullOrEmpty(sid)) {
+                try {
+                    var identifier = new System.Security.Principal.SecurityIdentifier(sid);
+                    UserAffected = identifier.Translate(typeof(System.Security.Principal.NTAccount)).ToString();
+                } catch {
+                    UserAffected = sid;
+                }
+            }
+        }
+
+        var privileges = _eventObject.GetValueFromDataDictionary("PrivilegeList");
+        if (!string.IsNullOrEmpty(privileges)) {
+            Rights = privileges.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries).ToList();
+            RightsTranslated = Rights.Select(EventsHelper.TranslatePrivilege).ToList();
+        } else {
+            Rights = new List<string>();
+            RightsTranslated = new List<string>();
+        }
+
+        Who = _eventObject.GetValueFromDataDictionary("SubjectUserName", "SubjectDomainName", "\\", reverseOrder: true);
+        When = _eventObject.TimeCreated;
+    }
+}

--- a/Sources/EventViewerX/SearchEvents.NamedEventsDetails.cs
+++ b/Sources/EventViewerX/SearchEvents.NamedEventsDetails.cs
@@ -120,6 +120,10 @@ namespace EventViewerX {
         /// </summary>
         ADUserPrivilegeUse,
         /// <summary>
+        /// User rights assigned or removed
+        /// </summary>
+        ADUserRightsAssignment,
+        /// <summary>
         /// Kerberos TGT requests
         /// </summary>
         KerberosTGTRequest,
@@ -267,6 +271,7 @@ namespace EventViewerX {
             { NamedEvents.ADUserLogonKerberos, ([4768], "Security") },
             { NamedEvents.ADUserUnlocked, ([4767], "Security") },
             { NamedEvents.ADUserPrivilegeUse, ([4672], "Security") },
+            { NamedEvents.ADUserRightsAssignment, (new List<int> { 4704, 4705 }, "Security") },
             { NamedEvents.KerberosTGTRequest, ([4768], "Security") },
             { NamedEvents.KerberosServiceTicket, (new List<int> { 4769, 4770 }, "Security") },
             { NamedEvents.KerberosTicketFailure, (new List<int> { 4771, 4772 }, "Security") },
@@ -378,6 +383,8 @@ namespace EventViewerX {
                             return new ADUserUnlocked(eventObject);
                         case NamedEvents.ADUserPrivilegeUse:
                             return new ADUserPrivilegeUse(eventObject);
+                        case NamedEvents.ADUserRightsAssignment:
+                            return new ADUserRightsAssignment(eventObject);
                         case NamedEvents.KerberosTGTRequest:
                             return new KerberosTGTRequest(eventObject);
                         case NamedEvents.KerberosServiceTicket:


### PR DESCRIPTION
## Summary
- add ADUserRightsAssignment rule for events 4704 and 4705
- register ADUserRightsAssignment in NamedEvents and map event IDs

## Testing
- `dotnet build Sources/EventViewerX.sln --no-restore --verbosity minimal`
- `dotnet test Sources/EventViewerX.sln --no-build --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_6864e321d2e4832e8c07a16f49f72950