### PR TITLE
Add validation for thread count

### DIFF
--- a/Sources/PSEventViewer/CmdletGetEVXEvent.cs
+++ b/Sources/PSEventViewer/CmdletGetEVXEvent.cs
@@ -117,6 +117,7 @@ public sealed class CmdletGetEVXEvent : AsyncPSCmdlet {
     [Parameter(Mandatory = false, ParameterSetName = "RecordId")]
     [Parameter(Mandatory = false, ParameterSetName = "GenericEvents")]
     [Parameter(Mandatory = false, ParameterSetName = "NamedEvents")]
+    [ValidateRange(1, int.MaxValue)]
     public int NumberOfThreads = 8;
 
     /// <summary>

--- a/Sources/PSEventViewer/CmdletStartEVXWatcher.cs
+++ b/Sources/PSEventViewer/CmdletStartEVXWatcher.cs
@@ -42,6 +42,7 @@ namespace PSEventViewer {
         /// Number of threads used for event processing.
         /// </summary>
         [Parameter(Mandatory = false)]
+        [ValidateRange(1, int.MaxValue)]
         public int NumberOfThreads { get; set; } = 8;
 
         /// <summary>

--- a/Tests/Get-EVXEvent.Tests.ps1
+++ b/Tests/Get-EVXEvent.Tests.ps1
@@ -163,3 +163,9 @@ Describe 'Get-EVXEvent - MessageRegex' {
         $events.Count | Should -Be 1
     }
 }
+
+Describe 'Get-EVXEvent - Parameter validation' {
+    It 'Fails when NumberOfThreads is less than 1' {
+        { Get-EVXEvent -LogName 'Application' -NumberOfThreads 0 } | Should -Throw
+    }
+}

--- a/Tests/Start-EVXWatcher.Tests.ps1
+++ b/Tests/Start-EVXWatcher.Tests.ps1
@@ -1,0 +1,5 @@
+Describe 'Start-EVXWatcher - Parameter validation' {
+    It 'Fails when NumberOfThreads is less than 1' {
+        { Start-EVXWatcher -MachineName $env:COMPUTERNAME -LogName 'Application' -EventId 1 -Action {} -NumberOfThreads 0 } | Should -Throw
+    }
+}


### PR DESCRIPTION
## Summary
- enforce number of threads validation on Get-EVXEvent and Start-EVXWatcher
- test failing values for `NumberOfThreads` on both cmdlets

## Testing
- `dotnet build Sources/EventViewerX.sln -c Release`
- `pwsh -NoLogo -NoProfile -Command ./PSEventViewer.Tests.ps1` *(fails: Write-Color not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_686530ccaf50832e80e51e81f1a66cf1