### PR TITLE
Handle null channel references

### DIFF
--- a/Sources/EventViewerX.Tests/TestBinaryWrappers.cs
+++ b/Sources/EventViewerX.Tests/TestBinaryWrappers.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace EventViewerX.Tests {
+    public class TestBinaryWrappers {
+        [Fact]
+        public void LogNamesEmptyWhenChannelReferencesMissing() {
+            if (!OperatingSystem.IsWindows()) return;
+            const string metadata = "name: Test\nguid: {00000000-0000-0000-0000-000000000000}\n";
+            var method = typeof(EventViewerX.BinaryWrappers).GetMethod("GetMetadataProperty", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(method);
+            var channelReferences = method!.Invoke(null, new object[] { metadata, "channelReferences" }) as string;
+            Assert.Null(channelReferences);
+            string[] logNames = channelReferences?.Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries).Select(s => s.Trim()).ToArray() ?? Array.Empty<string>();
+            Assert.Empty(logNames);
+        }
+    }
+}

--- a/Sources/EventViewerX/BinaryWrappers.cs
+++ b/Sources/EventViewerX/BinaryWrappers.cs
@@ -91,7 +91,7 @@ namespace EventViewerX {
                 string metadata = GetProviderMetadata(provider);
                 string name = GetMetadataProperty(metadata, "name");
                 string guid = GetMetadataProperty(metadata, "guid");
-                string[] logNames = GetMetadataProperty(metadata, "channelReferences").Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries).Select(s => s.Trim()).ToArray();
+                string[] logNames = GetMetadataProperty(metadata, "channelReferences")?.Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries).Select(s => s.Trim()).ToArray() ?? Array.Empty<string>();
                 Console.WriteLine($"Provider Name: {name}, Provider GUID: {guid}, Log Names: {string.Join(", ", logNames)}");
             }
         }


### PR DESCRIPTION
## Summary
- avoid null reference when provider metadata lacks `channelReferences`
- add test for missing provider metadata

## Testing
- `dotnet test Sources/EventViewerX.Tests/EventViewerX.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_686530f47f54832eb6d0df3073f9d350