### PR TITLE
Fix time helper to use local time

### DIFF
--- a/Sources/EventViewerX.Tests/TestTimeHelper.cs
+++ b/Sources/EventViewerX.Tests/TestTimeHelper.cs
@@ -1,0 +1,41 @@
+using System;
+using Xunit;
+
+namespace EventViewerX.Tests {
+    public class TestTimeHelper {
+        [Fact]
+        public void PastHourRangeIsLocal() {
+            var now = DateTime.Now;
+            var expectedStart = new DateTime(now.Year, now.Month, now.Day, now.Hour, 0, 0).AddHours(-1);
+            var expectedEnd = expectedStart.AddHours(1);
+
+            var result = TimeHelper.GetTimePeriod(TimePeriod.PastHour);
+
+            Assert.Equal(expectedStart, result.StartTime);
+            Assert.Equal(expectedEnd, result.EndTime);
+        }
+
+        [Fact]
+        public void LastSevenDaysStartsFromLocal() {
+            var now = DateTime.Now;
+            var expectedStart = now.Date.AddDays(-7);
+
+            var result = TimeHelper.GetTimePeriod(TimePeriod.Last7Days);
+
+            Assert.Equal(expectedStart, result.StartTime);
+            Assert.Null(result.EndTime);
+        }
+
+        [Fact]
+        public void TodayRangeMatchesLocalDay() {
+            var now = DateTime.Now;
+            var expectedStart = new DateTime(now.Year, now.Month, now.Day, 0, 0, 0);
+            var expectedEnd = expectedStart.AddDays(1);
+
+            var result = TimeHelper.GetTimePeriod(TimePeriod.Today);
+
+            Assert.Equal(expectedStart, result.StartTime);
+            Assert.Equal(expectedEnd, result.EndTime);
+        }
+    }
+}

--- a/Sources/EventViewerX/EventViewerX.csproj
+++ b/Sources/EventViewerX/EventViewerX.csproj
@@ -15,9 +15,14 @@
         <SupportedOSPlatform>windows</SupportedOSPlatform>
     </PropertyGroup>
 
-    <ItemGroup>
+  <ItemGroup>
         <PackageReference Include="DnsClientX" Version="0.4.0" />
-    </ItemGroup>
+  </ItemGroup>
+  <ItemGroup>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+            <_Parameter1>EventViewerX.Tests</_Parameter1>
+        </AssemblyAttribute>
+  </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
         <PackageReference Include="System.DirectoryServices" Version="8.0.0" />

--- a/Sources/EventViewerX/TimeHelper.cs
+++ b/Sources/EventViewerX/TimeHelper.cs
@@ -34,7 +34,7 @@ namespace EventViewerX {
 
     internal static class TimeHelper {
         internal static (DateTime? StartTime, DateTime? EndTime, TimeSpan? LastPeriod) GetTimePeriod(TimePeriod timePeriod) {
-            DateTime now = DateTime.UtcNow;
+            DateTime now = DateTime.Now;
             DateTime? startTime = null;
             DateTime? endTime = null;
             TimeSpan? lastPeriod = null;
@@ -76,13 +76,13 @@ namespace EventViewerX {
                     endTime = startTime.Value.AddMonths(3);
                     break;
                 case TimePeriod.Last3Days:
-                    startTime = DateTime.UtcNow.Date.AddDays(-3);
+                    startTime = now.Date.AddDays(-3);
                     break;
                 case TimePeriod.Last7Days:
-                    startTime = DateTime.UtcNow.Date.AddDays(-7);
+                    startTime = now.Date.AddDays(-7);
                     break;
                 case TimePeriod.Last14Days:
-                    startTime = DateTime.UtcNow.Date.AddDays(-14);
+                    startTime = now.Date.AddDays(-14);
                     break;
                 case TimePeriod.Last1Hours:
                     lastPeriod = TimeSpan.FromHours(1);


### PR DESCRIPTION
## Summary
- use `DateTime.Now` when determining query ranges
- expose internals to tests
- add unit tests checking time ranges are local

## Testing
- `dotnet build Sources/EventViewerX/EventViewerX.csproj`
- `dotnet test Sources/EventViewerX.Tests/EventViewerX.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_6865311602c0832e9b1af8673e9efdff