### PR TITLE
Validate category bounds

### DIFF
--- a/Sources/EventViewerX.Tests/TestWriteEvent.cs
+++ b/Sources/EventViewerX.Tests/TestWriteEvent.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Diagnostics;
+using Xunit;
+
+namespace EventViewerX.Tests {
+    public class TestWriteEvent {
+        [Fact]
+        public void InvalidCategoryThrows() {
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                SearchEvents.WriteEvent("TestSource", "Application", "Test", EventLogEntryType.Information, short.MaxValue + 1, 1, null)
+            );
+        }
+    }
+}

--- a/Sources/EventViewerX/SearchEvents.WriteEvent.cs
+++ b/Sources/EventViewerX/SearchEvents.WriteEvent.cs
@@ -44,6 +44,10 @@ public partial class SearchEvents : Settings {
     /// <param name="rawData">The raw data.</param>
     /// <param name="replacementStrings">The replacement strings.</param>
     public static void WriteEvent(string source, string log, string message, EventLogEntryType type, int category, int eventId, string machineName, byte[] rawData, params string[] replacementStrings) {
+        if (category is < short.MinValue or > short.MaxValue) {
+            throw new ArgumentOutOfRangeException(nameof(category), category, $"Category must fit into Int16 range ({short.MinValue} - {short.MaxValue}).");
+        }
+
         // Check if the event source exists. If not, create it.
         var sourceExists = CreateLogSource(source, log, machineName);
         if (sourceExists) {


### PR DESCRIPTION
## Summary
- ensure `WriteEvent` validates that category fits into a `short`
- add unit test for invalid category

## Testing
- `dotnet test Sources/EventViewerX.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_686548692b0c832eaf71039f8b553c12