### PR TITLE
Add Hyper-V VM start rule

### DIFF
--- a/Sources/EventViewerX/Enums/NamedEvents.cs
+++ b/Sources/EventViewerX/Enums/NamedEvents.cs
@@ -227,5 +227,9 @@
         /// Group Policy client-side processing events from System log
         /// </summary>
         ClientGroupPoliciesSystem,
+        /// <summary>
+        /// Hyper-V virtual machine started
+        /// </summary>
+        HyperVVirtualMachineStarted,
     }
 }

--- a/Sources/EventViewerX/Rules/HyperV/HyperVVirtualMachineStarted.cs
+++ b/Sources/EventViewerX/Rules/HyperV/HyperVVirtualMachineStarted.cs
@@ -1,0 +1,30 @@
+namespace EventViewerX.Rules.HyperV;
+
+/// <summary>
+/// Hyper-V virtual machine started
+/// 18500: The virtual machine was started
+/// </summary>
+public class HyperVVirtualMachineStarted : EventRuleBase {
+    public override List<int> EventIds => new() { 18500 };
+    public override string LogName => "Microsoft-Windows-Hyper-V-VMMS/Admin";
+    public override NamedEvents NamedEvent => NamedEvents.HyperVVirtualMachineStarted;
+
+    public override bool CanHandle(EventObject eventObject) {
+        // Simple rule - always handle if event ID and log name match
+        return true;
+    }
+
+    public string Computer;
+    public string VirtualMachine;
+    public string VirtualMachineId;
+    public DateTime When;
+
+    public HyperVVirtualMachineStarted(EventObject eventObject) : base(eventObject) {
+        _eventObject = eventObject;
+        Type = "HyperVVirtualMachineStarted";
+        Computer = _eventObject.ComputerName;
+        VirtualMachine = _eventObject.GetValueFromDataDictionary("Name", "VMName");
+        VirtualMachineId = _eventObject.GetValueFromDataDictionary("VMId", "VirtualMachineId");
+        When = _eventObject.TimeCreated;
+    }
+}


### PR DESCRIPTION
## Summary
- define `HyperVVirtualMachineStarted` event type
- add `HyperVVirtualMachineStarted` rule for event 18500 from Hyper-V VMMS log

## Testing
- `dotnet build Sources/EventViewerX/EventViewerX.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6865480d8de4832ea1530e37bf6f74d7