### PR TITLE
Add missing XML docs

### DIFF
--- a/Sources/EventViewerX/Rules/ActiveDirectory/Computers/ADComputerChangeDetailed.cs
+++ b/Sources/EventViewerX/Rules/ActiveDirectory/Computers/ADComputerChangeDetailed.cs
@@ -36,7 +36,7 @@ public class ADComputerChangeDetailed : EventRuleBase {
     /// <summary>
     /// Active Directory Computer Change Detailed
     /// </summary>
-    /// <param name="eventObject"></param>
+    /// <param name="eventObject">Underlying event record.</param>
     public ADComputerChangeDetailed(EventObject eventObject) : base(eventObject) {
         // common fields
         _eventObject = eventObject;

--- a/Sources/EventViewerX/Rules/ActiveDirectory/GroupPolicies/ADGroupPolicyChanges.cs
+++ b/Sources/EventViewerX/Rules/ActiveDirectory/GroupPolicies/ADGroupPolicyChanges.cs
@@ -1,5 +1,8 @@
 ﻿namespace EventViewerX.Rules.ActiveDirectory;
 
+/// <summary>
+/// Summary information for group policy change events.
+/// </summary>
 public class ADGroupPolicyChanges : EventRuleBase {
     public string Computer;
     public string Action;

--- a/Sources/EventViewerX/Rules/ActiveDirectory/GroupPolicies/ADGroupPolicyChangesDetailed.cs
+++ b/Sources/EventViewerX/Rules/ActiveDirectory/GroupPolicies/ADGroupPolicyChangesDetailed.cs
@@ -1,5 +1,8 @@
 ﻿namespace EventViewerX.Rules.ActiveDirectory;
 
+/// <summary>
+/// Detailed audit information for group policy changes.
+/// </summary>
 public class ADGroupPolicyChangesDetailed : EventObjectSlim {
     public string Computer;
     public string Action;

--- a/Sources/EventViewerX/Rules/ActiveDirectory/GroupPolicies/ADGroupPolicyEdits.cs
+++ b/Sources/EventViewerX/Rules/ActiveDirectory/GroupPolicies/ADGroupPolicyEdits.cs
@@ -2,6 +2,9 @@
 
 namespace EventViewerX.Rules.ActiveDirectory;
 
+/// <summary>
+/// Represents edits made to group policy objects.
+/// </summary>
 public class ADGroupPolicyEdits : EventRuleBase {
     public string Computer;
     public string Action;

--- a/Sources/EventViewerX/Rules/ActiveDirectory/GroupPolicies/GpoCreated.cs
+++ b/Sources/EventViewerX/Rules/ActiveDirectory/GroupPolicies/GpoCreated.cs
@@ -1,5 +1,8 @@
 ﻿namespace EventViewerX.Rules.ActiveDirectory;
 
+/// <summary>
+/// Represents a newly created group policy object event.
+/// </summary>
 public class GpoCreated : EventRuleBase {
     public string Computer;
     public string Action;

--- a/Sources/EventViewerX/Rules/ActiveDirectory/GroupPolicies/GpoDeleted.cs
+++ b/Sources/EventViewerX/Rules/ActiveDirectory/GroupPolicies/GpoDeleted.cs
@@ -1,5 +1,8 @@
 ﻿namespace EventViewerX.Rules.ActiveDirectory;
 
+/// <summary>
+/// Represents a deleted group policy object event.
+/// </summary>
 public class GpoDeleted : EventRuleBase {
     public string Computer;
     public string Action;

--- a/Sources/EventViewerX/Rules/ActiveDirectory/GroupPolicies/GpoModified.cs
+++ b/Sources/EventViewerX/Rules/ActiveDirectory/GroupPolicies/GpoModified.cs
@@ -1,5 +1,8 @@
 ﻿namespace EventViewerX.Rules.ActiveDirectory;
 
+/// <summary>
+/// Represents a modified group policy object event.
+/// </summary>
 public class GpoModified : EventRuleBase {
     public string Computer;
     public string Action;

--- a/Sources/EventViewerX/Rules/ActiveDirectory/OrganizationalUnit/ADOrganizationalUnitChangeDetailed.cs
+++ b/Sources/EventViewerX/Rules/ActiveDirectory/OrganizationalUnit/ADOrganizationalUnitChangeDetailed.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 
 namespace EventViewerX.Rules.ActiveDirectory {
+    /// <summary>
+    /// Represents detailed organizational unit change events.
+    /// </summary>
     public class ADOrganizationalUnitChangeDetailed : EventRuleBase {
 
 

--- a/Sources/EventViewerX/Rules/ActiveDirectory/Replication/Replication.cs
+++ b/Sources/EventViewerX/Rules/ActiveDirectory/Replication/Replication.cs
@@ -1,5 +1,8 @@
 ﻿namespace EventViewerX.Rules.ActiveDirectory;
 
+/// <summary>
+/// Placeholder for Active Directory replication events documentation.
+/// </summary>
 internal class Replication {
 
     //Log Name:      Directory Service

--- a/Sources/EventViewerX/Rules/Kerberos/KerberosPolicyChange.cs
+++ b/Sources/EventViewerX/Rules/Kerberos/KerberosPolicyChange.cs
@@ -1,5 +1,8 @@
 ﻿namespace EventViewerX.Rules.Kerberos;
 
+/// <summary>
+/// Kerberos policy configuration change event details.
+/// </summary>
 public class KerberosPolicyChange : EventObjectSlim
 {
     public string Computer;

--- a/Sources/EventViewerX/Rules/Kerberos/KerberosServiceTicket.cs
+++ b/Sources/EventViewerX/Rules/Kerberos/KerberosServiceTicket.cs
@@ -1,5 +1,8 @@
 ﻿namespace EventViewerX.Rules.Kerberos;
 
+/// <summary>
+/// Represents a Kerberos service ticket request event.
+/// </summary>
 public class KerberosServiceTicket : EventObjectSlim
 {
     public string Computer;

--- a/Sources/EventViewerX/Rules/Kerberos/KerberosTGTRequest.cs
+++ b/Sources/EventViewerX/Rules/Kerberos/KerberosTGTRequest.cs
@@ -1,5 +1,8 @@
 ﻿namespace EventViewerX.Rules.Kerberos;
 
+/// <summary>
+/// Represents a Kerberos TGT request event.
+/// </summary>
 public class KerberosTGTRequest : EventObjectSlim
 {
     public string Computer;

--- a/Sources/EventViewerX/Rules/Kerberos/KerberosTicketFailure.cs
+++ b/Sources/EventViewerX/Rules/Kerberos/KerberosTicketFailure.cs
@@ -1,5 +1,8 @@
 ﻿namespace EventViewerX.Rules.Kerberos;
 
+/// <summary>
+/// Represents a failed Kerberos ticket request event.
+/// </summary>
 public class KerberosTicketFailure : EventObjectSlim
 {
     public string Computer;

--- a/Sources/EventViewerX/Rules/Windows/ClientGroupPolicies.cs
+++ b/Sources/EventViewerX/Rules/Windows/ClientGroupPolicies.cs
@@ -1,5 +1,8 @@
 namespace EventViewerX.Rules.Windows;
 
+/// <summary>
+/// Represents client side group policy processing details.
+/// </summary>
 public class ClientGroupPolicies : EventObjectSlim {
     public string Computer;
     public string Action;

--- a/Sources/EventViewerX/SearchEvents.GetProviders.cs
+++ b/Sources/EventViewerX/SearchEvents.GetProviders.cs
@@ -1,4 +1,7 @@
 ﻿namespace EventViewerX {
+    /// <summary>
+    /// Placeholder for future provider related methods.
+    /// </summary>
     public partial class SearchEvents : Settings {
 
         //public static void GetProviderList() {

--- a/Sources/EventViewerX/SearchEvents.GetPublisher.cs
+++ b/Sources/EventViewerX/SearchEvents.GetPublisher.cs
@@ -5,6 +5,9 @@ using System.Diagnostics.Eventing.Reader;
 using System.Linq;
 
 namespace EventViewerX {
+    /// <summary>
+    /// Functions for retrieving event provider metadata.
+    /// </summary>
     public partial class SearchEvents : Settings {
 
         /// <summary>
@@ -12,6 +15,10 @@ namespace EventViewerX {
         /// </summary>
         private static readonly ConcurrentDictionary<string, Metadata> _providerMetadataCache = new(StringComparer.OrdinalIgnoreCase);
 
+        /// <summary>
+        /// Retrieves available event providers on the local machine.
+        /// </summary>
+        /// <returns>Enumeration of provider metadata.</returns>
         public static IEnumerable<Metadata> GetProviders() {
             EventLogSession session = new EventLogSession();
             foreach (string providerName in session.GetProviderNames()) {
@@ -37,12 +44,18 @@ namespace EventViewerX {
             }
         }
 
+        /// <summary>
+        /// Returns provider metadata as a list.
+        /// </summary>
         public static List<Metadata> GetProviderList() {
             return GetProviders().ToList();
         }
 
     }
 
+    /// <summary>
+    /// Lightweight provider metadata container.
+    /// </summary>
     public class Metadata {
         public string ProviderName;
         public string DisplayName;

--- a/Sources/EventViewerX/SearchEvents.LogDetails.cs
+++ b/Sources/EventViewerX/SearchEvents.LogDetails.cs
@@ -3,6 +3,9 @@ using System.Text.RegularExpressions;
 
 namespace EventViewerX;
 
+/// <summary>
+/// Helper methods for retrieving event log configuration details.
+/// </summary>
 public partial class SearchEvents : Settings {
 
     public static IEnumerable<EventLogDetails> DisplayEventLogs(string[] listLog = null, string machineName = null) {

--- a/Sources/EventViewerX/SearchEvents.NamedEventsDetails.cs
+++ b/Sources/EventViewerX/SearchEvents.NamedEventsDetails.cs
@@ -12,9 +12,9 @@ namespace EventViewerX {
         /// <summary>
         /// Builds the appropriate event object based on the NamedEvents value
         /// </summary>
-        /// <param name="eventObject"></param>
-        /// <param name="typeEventsList"></param>
-        /// <returns></returns>
+        /// <param name="eventObject">Event to evaluate.</param>
+        /// <param name="typeEventsList">List of target event types.</param>
+        /// <returns>Concrete event rule instance or null.</returns>
         /// <exception cref="ArgumentException"></exception>
         private static EventObjectSlim BuildTargetEvents(EventObject eventObject, List<NamedEvents> typeEventsList) {
             // Use the new reflection-based system - let each rule decide if it can handle the event

--- a/Sources/EventViewerX/SearchEvents.PowerShellScripts.cs
+++ b/Sources/EventViewerX/SearchEvents.PowerShellScripts.cs
@@ -6,6 +6,9 @@ using System.Text;
 using System.Xml.Linq;
 
 namespace EventViewerX {
+    /// <summary>
+    /// Methods for working with PowerShell script execution events.
+    /// </summary>
     public partial class SearchEvents {
         public static IEnumerable<PowerShellScriptExecutionInfo> GetPowerShellScriptExecution(
             PowerShellEdition type,

--- a/Sources/EventViewerX/SearchEvents.QueryLog.cs
+++ b/Sources/EventViewerX/SearchEvents.QueryLog.cs
@@ -24,7 +24,7 @@ public partial class SearchEvents : Settings {
     /// </summary>
     /// <param name="query">The query.</param>
     /// <param name="machineName">Name of the machine.</param>
-    /// <returns></returns>
+    /// <returns>Initialized <see cref="EventLogReader"/> or null when failed.</returns>
     private static EventLogReader CreateEventLogReader(EventLogQuery query, string machineName) {
         if (query == null) {
             _logger.WriteWarning($"An error occurred on {machineName} while creating the event log reader: Query cannot be null.");
@@ -48,7 +48,7 @@ public partial class SearchEvents : Settings {
     /// <summary>
     /// Get the fully qualified domain name of the machine
     /// </summary>
-    /// <returns></returns>
+    /// <returns>Machine FQDN.</returns>
     private static string GetFQDN() {
         try {
             return Dns.GetHostEntry("").HostName;
@@ -180,7 +180,7 @@ public partial class SearchEvents : Settings {
     /// <param name="maxEvents">The maximum events.</param>
     /// <param name="eventRecordId">The event record identifier.</param>
     /// <param name="timePeriod">The time period.</param>
-    /// <returns></returns>
+    /// <returns>Enumerable collection of matching events.</returns>
     public static IEnumerable<EventObject> QueryLog(string logName, List<int> eventIds = null, string machineName = null, string providerName = null, Keywords? keywords = null, Level? level = null, DateTime? startTime = null, DateTime? endTime = null, string userId = null, int maxEvents = 0, List<long> eventRecordId = null, TimePeriod? timePeriod = null, CancellationToken cancellationToken = default) {
         if (eventIds != null && eventIds.Any(id => id <= 0)) {
             throw new ArgumentException("Event IDs must be positive.", nameof(eventIds));
@@ -237,8 +237,8 @@ public partial class SearchEvents : Settings {
     /// <summary>
     /// Build a query string for querying a log for a specific event record ID or IDs
     /// </summary>
-    /// <param name="eventRecordIds"></param>
-    /// <returns></returns>
+    /// <param name="eventRecordIds">Event record identifiers.</param>
+    /// <returns>XML query string.</returns>
     private static string BuildQueryString(List<long> eventRecordIds) {
         if (eventRecordIds != null) {
             var validIds = eventRecordIds.Where(id => id > 0).ToList();
@@ -265,7 +265,7 @@ public partial class SearchEvents : Settings {
     /// <param name="tasks">The tasks.</param>
     /// <param name="opcodes">The opcodes.</param>
     /// <param name="timePeriod">The time period.</param>
-    /// <returns></returns>
+    /// <returns>XML query string.</returns>
     private static string BuildQueryString(string logName, List<int> eventIds = null, string providerName = null, Keywords? keywords = null, Level? level = null, DateTime? startTime = null, DateTime? endTime = null, string userId = null, List<int> tasks = null, List<int> opcodes = null, TimePeriod? timePeriod = null) {
         TimeSpan? lastPeriod = null;
         if (timePeriod.HasValue) {

--- a/Sources/EventViewerX/SearchEvents.QueryNamedEvents.cs
+++ b/Sources/EventViewerX/SearchEvents.QueryNamedEvents.cs
@@ -5,8 +5,23 @@ using System.Linq;
 using System.Threading;
 using System.Runtime.CompilerServices;
 namespace EventViewerX {
+    /// <summary>
+    /// Methods for querying events by predefined named event types.
+    /// </summary>
     public partial class SearchEvents : Settings {
 
+        /// <summary>
+        /// Searches logs for events matching the provided named event types.
+        /// </summary>
+        /// <param name="typeEventsList">Event types to locate.</param>
+        /// <param name="machineNames">Target machines to query.</param>
+        /// <param name="startTime">Optional start time.</param>
+        /// <param name="endTime">Optional end time.</param>
+        /// <param name="timePeriod">Predefined time period.</param>
+        /// <param name="maxThreads">Maximum parallel threads.</param>
+        /// <param name="maxEvents">Maximum events to return.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Asynchronous sequence of simplified events.</returns>
         public static async IAsyncEnumerable<EventObjectSlim> FindEventsByNamedEvents(List<NamedEvents> typeEventsList, List<string> machineNames = null, DateTime? startTime = null, DateTime? endTime = null, TimePeriod? timePeriod = null, int maxThreads = 8, int maxEvents = 0, [EnumeratorCancellation] CancellationToken cancellationToken = default) {
             // Use the new reflection-based system to get event info
             var eventInfoDict = EventObjectSlim.GetEventInfoForNamedEvents(typeEventsList);

--- a/Sources/EventViewerX/SearchEvents.WinEventFilter.cs
+++ b/Sources/EventViewerX/SearchEvents.WinEventFilter.cs
@@ -40,6 +40,9 @@ public partial class SearchEvents {
     /// </summary>
     private static readonly ConcurrentDictionary<string, string> userSidCache = new ConcurrentDictionary<string, string>();
 
+    /// <summary>
+    /// Builds an XPath query string based on provided filter criteria.
+    /// </summary>
     public static string BuildWinEventFilter(
         string[]? id = null,
         string[]? eventRecordId = null,

--- a/Sources/EventViewerX/SearchEvents.WinEventInformation.cs
+++ b/Sources/EventViewerX/SearchEvents.WinEventInformation.cs
@@ -6,6 +6,9 @@ using System.Linq;
 using System.Security.AccessControl;
 
 namespace EventViewerX {
+    /// <summary>
+    /// Utility methods for retrieving basic Windows event log information.
+    /// </summary>
     public partial class SearchEvents : Settings {
         public static IEnumerable<WinEventInformation> GetWinEventInformation(string[]? logNames, List<string>? machines, List<string>? filePaths, int maxDegreeOfParallelism = 50) {
             if (machines == null || machines.Count == 0) {

--- a/Sources/EventViewerX/SearchEvents.WriteEvent.cs
+++ b/Sources/EventViewerX/SearchEvents.WriteEvent.cs
@@ -92,7 +92,7 @@ public partial class SearchEvents : Settings {
     /// <param name="source">The source.</param>
     /// <param name="log">The log.</param>
     /// <param name="machineName">Name of the machine.</param>
-    /// <returns></returns>
+    /// <returns><c>true</c> when source exists or is created.</returns>
     public static bool CreateLogSource(string source, string log, string machineName = null) {
         try {
             if (string.IsNullOrEmpty(machineName)) {

--- a/Sources/EventViewerX/SearchEvents.WriteEventEx.cs
+++ b/Sources/EventViewerX/SearchEvents.WriteEventEx.cs
@@ -3,6 +3,9 @@ using System.Runtime.InteropServices;
 using System.Text;
 
 namespace EventViewerX {
+    /// <summary>
+    /// Advanced helpers for writing custom events via EventWriteEx.
+    /// </summary>
     public partial class SearchEvents : Settings {
 
         [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]


### PR DESCRIPTION
## Summary
- document various Rules classes
- add summaries for SearchEvents partial class files
- fill in param and returns XML docs for SearchEvents helpers

## Testing
- `dotnet build Sources/EventViewerX.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68654850ea98832eb89b6ce035d85010