### PR TITLE
Limit Start-EVXWatcher threads

### DIFF
--- a/Sources/PSEventViewer/CmdletStartEVXWatcher.cs
+++ b/Sources/PSEventViewer/CmdletStartEVXWatcher.cs
@@ -42,7 +42,7 @@ namespace PSEventViewer {
         /// Number of threads used for event processing.
         /// </summary>
         [Parameter(Mandatory = false)]
-        [ValidateRange(1, int.MaxValue)]
+        [ValidateRange(1, 1024)]
         public int NumberOfThreads { get; set; } = 8;
 
         /// <summary>

--- a/Tests/Start-EVXWatcher.Tests.ps1
+++ b/Tests/Start-EVXWatcher.Tests.ps1
@@ -2,4 +2,7 @@ Describe 'Start-EVXWatcher - Parameter validation' {
     It 'Fails when NumberOfThreads is less than 1' {
         { Start-EVXWatcher -MachineName $env:COMPUTERNAME -LogName 'Application' -EventId 1 -Action {} -NumberOfThreads 0 } | Should -Throw
     }
+    It 'Fails when NumberOfThreads is greater than 1024' {
+        { Start-EVXWatcher -MachineName $env:COMPUTERNAME -LogName 'Application' -EventId 1 -Action {} -NumberOfThreads 2000 } | Should -Throw
+    }
 }


### PR DESCRIPTION
## Summary
- add validation cap to `NumberOfThreads` parameter
- ensure Start-EVXWatcher tests cover invalid upper bound

## Testing
- `dotnet build Sources/EventViewerX.sln`
- `pwsh -NoLogo -NoProfile -Command ./PSEventViewer.Tests.ps1` *(fails: Write-Color / Pester not found)*

------
https://chatgpt.com/codex/tasks/task_e_686548641f8c832e863beb5f1e86915a