### PR TITLE
Add BugCheck event rule

### DIFF
--- a/Sources/EventViewerX.Examples/Examples.FindBasic.cs
+++ b/Sources/EventViewerX.Examples/Examples.FindBasic.cs
@@ -5,7 +5,7 @@ namespace EventViewerX.Examples {
     internal partial class Examples {
         public static async Task FindEventsTargetedBasic() {
 
-            await foreach (var foundObject in SearchEvents.FindEventsByNamedEvents([NamedEvents.OSCrash, NamedEvents.OSStartupShutdownCrash])) {
+            await foreach (var foundObject in SearchEvents.FindEventsByNamedEvents([NamedEvents.OSCrash, NamedEvents.OSStartupShutdownCrash, NamedEvents.OSBugCheck])) {
 
                 Console.WriteLine("Event ID: {0}", foundObject.EventID + ", " + foundObject.Type + " " + foundObject.GatheredFrom);
                 Console.WriteLine("Type: " + foundObject.Type + ", " + foundObject.EventID + " " + foundObject.EventID + " " + foundObject.GatheredFrom);
@@ -20,6 +20,10 @@ namespace EventViewerX.Examples {
                     Console.WriteLine("[*] Computer: " + osStartupShutdownCrash.Computer);
                     Console.WriteLine("[*] Who: " + osStartupShutdownCrash.Action);
                     Console.WriteLine("[*] When: " + osStartupShutdownCrash.When);
+                } else if (foundObject is OSBugCheck bugCheck) {
+                    Console.WriteLine("[*] Computer: " + bugCheck.Computer);
+                    Console.WriteLine("[*] Bugcheck: " + bugCheck.BugCheckCode);
+                    Console.WriteLine("[*] When: " + bugCheck.When);
                 }
             }
         }

--- a/Sources/EventViewerX/Enums/NamedEvents.cs
+++ b/Sources/EventViewerX/Enums/NamedEvents.cs
@@ -234,9 +234,14 @@
 
         /// <summary>
         /// Unexpected system shutdown
-        /// </summary>      
+        /// </summary>
         OSCrash,
-      
+
+        /// <summary>
+        /// Bugcheck event describing a system crash
+        /// </summary>
+        OSBugCheck,
+
         /// <summary>
         /// System start-up, shutdown or crash events
         /// </summary>

--- a/Sources/EventViewerX/Rules/Windows/OSBugCheck.cs
+++ b/Sources/EventViewerX/Rules/Windows/OSBugCheck.cs
@@ -1,0 +1,40 @@
+namespace EventViewerX.Rules.Windows;
+
+/// <summary>
+/// System bugcheck event
+/// 1001: The computer has rebooted from a bugcheck.
+/// </summary>
+public class OSBugCheck : EventRuleBase {
+    public override List<int> EventIds => new() { 1001 };
+    public override string LogName => "System";
+    public override NamedEvents NamedEvent => NamedEvents.OSBugCheck;
+
+    public override bool CanHandle(EventObject eventObject) {
+        // Simple rule - always handle if event ID and log name match
+        return true;
+    }
+
+    public string Computer;
+    public string BugCheckCode;
+    public string Parameter1;
+    public string Parameter2;
+    public string Parameter3;
+    public string Parameter4;
+    public string DumpFile;
+    public string ReportId;
+    public DateTime When;
+
+    public OSBugCheck(EventObject eventObject) : base(eventObject) {
+        _eventObject = eventObject;
+        Type = "OSBugCheck";
+        Computer = _eventObject.ComputerName;
+        BugCheckCode = _eventObject.GetValueFromDataDictionary("BugcheckCode", "param1");
+        Parameter1 = _eventObject.GetValueFromDataDictionary("BugcheckParameter1", "param2");
+        Parameter2 = _eventObject.GetValueFromDataDictionary("BugcheckParameter2", "param3");
+        Parameter3 = _eventObject.GetValueFromDataDictionary("BugcheckParameter3", "param4");
+        Parameter4 = _eventObject.GetValueFromDataDictionary("BugcheckParameter4", "param5");
+        DumpFile = _eventObject.GetValueFromDataDictionary("DumpFile");
+        ReportId = _eventObject.GetValueFromDataDictionary("ReportId");
+        When = _eventObject.TimeCreated;
+    }
+}


### PR DESCRIPTION
## Summary
- add new `OSBugCheck` event rule to capture BugCheck events (ID 1001)
- expose the new rule via `NamedEvents`
- demonstrate use in basic example

## Testing
- `dotnet build Sources/EventViewerX/EventViewerX.csproj -c Release`
- `dotnet build Sources/PSEventViewer/PSEventViewer.csproj -c Release`
- `pwsh -NoLogo -NoProfile -NonInteractive -Command ./PSEventViewer.Tests.ps1` *(fails: Write-Color/Invoke-Pester not found)*

------
https://chatgpt.com/codex/tasks/task_e_68654fa68e0c832e960556337d03d3c3