### PR TITLE
Capture DHCP lease events

### DIFF
--- a/Sources/EventViewerX/Enums/NamedEvents.cs
+++ b/Sources/EventViewerX/Enums/NamedEvents.cs
@@ -209,6 +209,11 @@
         FirewallRuleChange,
 
         /// <summary>
+        /// DHCP lease creation event
+        /// </summary>
+        DhcpLeaseCreated,
+
+        /// <summary>
         /// BitLocker protection key changed or backed up
         /// </summary>
         BitLockerKeyChange,

--- a/Sources/EventViewerX/Rules/DHCP/DhcpLeaseCreated.cs
+++ b/Sources/EventViewerX/Rules/DHCP/DhcpLeaseCreated.cs
@@ -1,0 +1,30 @@
+namespace EventViewerX.Rules.DHCP;
+
+/// <summary>
+/// DHCP lease creation event
+/// 10: A new IP address was leased to a client
+/// </summary>
+public class DhcpLeaseCreated : EventRuleBase {
+    public override List<int> EventIds => new() { 10 };
+    public override string LogName => "Microsoft-Windows-DHCP Server/Operational";
+    public override NamedEvents NamedEvent => NamedEvents.DhcpLeaseCreated;
+
+    public override bool CanHandle(EventObject eventObject) {
+        // Always handle if event ID and log name match
+        return true;
+    }
+
+    public string Computer;
+    public string IPAddress;
+    public string MacAddress;
+    public DateTime When;
+
+    public DhcpLeaseCreated(EventObject eventObject) : base(eventObject) {
+        _eventObject = eventObject;
+        Type = "DhcpLeaseCreated";
+        Computer = _eventObject.ComputerName;
+        IPAddress = _eventObject.GetValueFromDataDictionary("IpAddress", "ClientIP");
+        MacAddress = _eventObject.GetValueFromDataDictionary("HWAddress", "MacAddress");
+        When = _eventObject.TimeCreated;
+    }
+}


### PR DESCRIPTION
## Summary
- add DhcpLeaseCreated rule for DHCP lease creation events
- expose new DhcpLeaseCreated named event

## Testing
- `dotnet restore Sources/EventViewerX.sln`
- `dotnet test Sources/EventViewerX.sln --no-restore`
- `dotnet build Sources/EventViewerX.sln --no-restore`


------
https://chatgpt.com/codex/tasks/task_e_68654f8cc4e4832ea0652b5d38a2c848