### PR TITLE
Handle BitLocker suspension event

### DIFF
--- a/Sources/EventViewerX/Enums/NamedEvents.cs
+++ b/Sources/EventViewerX/Enums/NamedEvents.cs
@@ -214,6 +214,11 @@
         BitLockerKeyChange,
 
         /// <summary>
+        /// BitLocker protection was suspended
+        /// </summary>
+        BitLockerSuspended,
+
+        /// <summary>
         /// External device recognized by the system
         /// </summary>
         DeviceRecognized,

--- a/Sources/EventViewerX/Rules/Windows/BitLockerSuspended.cs
+++ b/Sources/EventViewerX/Rules/Windows/BitLockerSuspended.cs
@@ -1,0 +1,30 @@
+namespace EventViewerX.Rules.Windows;
+
+/// <summary>
+/// BitLocker protection suspended
+/// 24660: BitLocker protection was suspended
+/// </summary>
+public class BitLockerSuspended : EventRuleBase {
+    public override List<int> EventIds => new() { 24660 };
+    public override string LogName => "BitLocker-API";
+    public override NamedEvents NamedEvent => NamedEvents.BitLockerSuspended;
+
+    public override bool CanHandle(EventObject eventObject) {
+        // Simple rule - always handle if event ID and log name match
+        return true;
+    }
+    public string Computer;
+    public BitLockerVolumeType? Volume;
+    public string Who;
+    public DateTime When;
+
+    public BitLockerSuspended(EventObject eventObject) : base(eventObject) {
+        _eventObject = eventObject;
+        Type = "BitLockerSuspended";
+        Computer = _eventObject.ComputerName;
+        Volume = EventsHelper.GetBitLockerVolumeType(
+            _eventObject.GetValueFromDataDictionary("VolumeName", "Volume"));
+        Who = _eventObject.GetValueFromDataDictionary("SubjectUserName", "SubjectDomainName", "\\", reverseOrder: true);
+        When = _eventObject.TimeCreated;
+    }
+}


### PR DESCRIPTION
## Summary
- parse BitLocker suspension events
- expose new `BitLockerSuspended` named event

## Testing
- `dotnet test Sources/EventViewerX.sln`

------
https://chatgpt.com/codex/tasks/task_e_68654f9d931c832eb7759c37f582c4ee