### PR TITLE
Add DFS Replication rule

### DIFF
--- a/Sources/EventViewerX/Enums/NamedEvents.cs
+++ b/Sources/EventViewerX/Enums/NamedEvents.cs
@@ -271,5 +271,10 @@
         /// Hyper-V virtual machine started
         /// </summary>
         HyperVVirtualMachineStarted,
+
+        /// <summary>
+        /// DFS Replication partner error
+        /// </summary>
+        DfsReplicationError,
     }
 }

--- a/Sources/EventViewerX/Rules/Windows/DfsReplicationError.cs
+++ b/Sources/EventViewerX/Rules/Windows/DfsReplicationError.cs
@@ -1,0 +1,29 @@
+namespace EventViewerX.Rules.Windows;
+
+/// <summary>
+/// DFS Replication partner communication failure
+/// 5002: The DFS Replication service encountered an error communicating with a partner.
+/// </summary>
+public class DfsReplicationError : EventRuleBase {
+    public override List<int> EventIds => new() { 5002 };
+    public override string LogName => "DFS Replication";
+    public override NamedEvents NamedEvent => NamedEvents.DfsReplicationError;
+
+    public override bool CanHandle(EventObject eventObject) {
+        return true;
+    }
+
+    public string ReplicationGroup;
+    public string ErrorCode;
+    public string Partner;
+    public DateTime When;
+
+    public DfsReplicationError(EventObject eventObject) : base(eventObject) {
+        _eventObject = eventObject;
+        Type = "DfsReplicationError";
+        ReplicationGroup = _eventObject.GetValueFromDataDictionary("Replication Group");
+        ErrorCode = _eventObject.GetValueFromDataDictionary("Error Code", "Error");
+        Partner = _eventObject.GetValueFromDataDictionary("Partner Name");
+        When = _eventObject.TimeCreated;
+    }
+}


### PR DESCRIPTION
## Summary
- track DFS Replication partner errors via Event ID 5002
- expose this as `DfsReplicationError` named event

## Testing
- `dotnet build Sources/EventViewerX/EventViewerX.csproj -c Release`
- `Invoke-Pester` *(fails: The term 'Invoke-Pester' is not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_6865631d495c832e8a072b6240f1d44f