### PR TITLE
Use concurrent collection and clean unused locks

### DIFF
--- a/Sources/EventViewerX/Logger/LoggingMessages.cs
+++ b/Sources/EventViewerX/Logger/LoggingMessages.cs
@@ -28,5 +28,4 @@ public class LoggingMessages {
         set => Logger.IsDebug = value;
     }
 
-    internal static object _LockObject = new object();
 }

--- a/Sources/EventViewerX/SearchEvents.QueryLog.cs
+++ b/Sources/EventViewerX/SearchEvents.QueryLog.cs
@@ -364,7 +364,7 @@ public partial class SearchEvents : Settings {
         var semaphore = new SemaphoreSlim(maxThreads);
         var results = new BlockingCollection<EventObject>();
 
-        var tasks = new List<Task>();
+        var tasks = new ConcurrentBag<Task>();
         foreach (var machineName in machineNames) {
             if (eventIds != null) {
                 var eventIdsChunks = eventIds.Select((x, i) => new { Index = i, Value = x })

--- a/Sources/EventViewerX/Settings.cs
+++ b/Sources/EventViewerX/Settings.cs
@@ -33,5 +33,4 @@ public class Settings {
     /// </summary>
     public int NumberOfThreads = 8;
 
-    protected readonly object _LockObject = new object();
 }


### PR DESCRIPTION
## Summary
- swap List for ConcurrentBag in `QueryLogsParallel`
- drop unused lock objects

## Testing
- `dotnet build Sources/EventViewerX/EventViewerX.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68658028f764832ea8f3e4b8649266b2