### PR TITLE
Implement resume support for multiple jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,11 @@ Our module tries to improve on that by providing a bit more flexibility and spee
 - [PowerShell - Everything you wanted to know about Event Logs and then some](https://evotec.xyz/powershell-everything-you-wanted-to-know-about-event-logs/)
 - [Sending information to Event Log with extended fields using PowerShell](https://evotec.xyz/sending-information-to-event-log-with-extended-fields-using-powershell/)
 - [The only PowerShell Command you will ever need to find out who did what in Active Directory](https://evotec.xyz/the-only-powershell-command-you-will-ever-need-to-find-out-who-did-what-in-active-directory/)
+
+### Long-running monitoring jobs
+
+`Get-EVXEvent` can keep track of the last processed record. Specify `-RecordIdFile` with a file path. The cmdlet stores the newest record ID there and automatically skips older events on the next run. When multiple monitoring jobs share the same file, use `-RecordIdKey` to persist a value per job.
+
+```powershell
+Get-EVXEvent -LogName Security -RecordIdFile C:\Temp\evx.state -RecordIdKey Machine1
+```

--- a/Sources/PSEventViewer/PSEventViewer.csproj
+++ b/Sources/PSEventViewer/PSEventViewer.csproj
@@ -16,9 +16,13 @@
     <ItemGroup>
         <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" PrivateAssets="all" />
     </ItemGroup>
-    <ItemGroup>
-        <ProjectReference Include="..\EventViewerX\EventViewerX.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+      <ProjectReference Include="..\EventViewerX\EventViewerX.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' or '$(TargetFramework)' == 'netstandard2.0' ">
+      <PackageReference Include="System.Text.Json" Version="9.0.0" />
+  </ItemGroup>
 
     <!-- Make sure the output DLL's from library are included in the output -->
     <PropertyGroup>


### PR DESCRIPTION
## Summary
- extend `Get-EVXEvent` with `RecordIdKey` for multi-job resume
- store/resume record IDs in JSON so one file can track multiple keys
- update long-running monitoring docs
- reference System.Text.Json for older targets

## Testing
- `dotnet build Sources/EventViewerX.sln -c Release`
- `pwsh ./PSEventViewer.Tests.ps1` *(fails: Write-Color/Invoke-Pester not found)*

------
https://chatgpt.com/codex/tasks/task_e_68657fc06634832eb2a1fc1b612f1c29