### PR TITLE
Add RecordId range parameters

### DIFF
--- a/Sources/EventViewerX/SearchEvents.WinEventFilter.cs
+++ b/Sources/EventViewerX/SearchEvents.WinEventFilter.cs
@@ -46,6 +46,8 @@ public partial class SearchEvents {
     public static string BuildWinEventFilter(
         string[]? id = null,
         string[]? eventRecordId = null,
+        long? recordIdFrom = null,
+        long? recordIdTo = null,
         DateTime? startTime = null,
         DateTime? endTime = null,
         string[]? data = null,
@@ -65,6 +67,12 @@ public partial class SearchEvents {
         }
         if (eventRecordId != null && eventRecordId.Length > 0) {
             filter = JoinXPathFilter(InitializeXPathFilter(eventRecordId, "EventRecordID={0}", "*[System[{0}]]"), filter);
+        }
+        if (recordIdFrom.HasValue) {
+            filter = JoinXPathFilter($"*[System[EventRecordID &gt;= {recordIdFrom.Value}]]", filter);
+        }
+        if (recordIdTo.HasValue) {
+            filter = JoinXPathFilter($"*[System[EventRecordID &lt;= {recordIdTo.Value}]]", filter);
         }
         if (excludeId != null && excludeId.Length > 0) {
             filter = JoinXPathFilter(InitializeXPathFilter(excludeId, "EventID!={0}", "*[System[{0}]]"), filter);

--- a/Sources/PSEventViewer/CmdletGetEVXEvent.cs
+++ b/Sources/PSEventViewer/CmdletGetEVXEvent.cs
@@ -223,7 +223,7 @@ public sealed class CmdletGetEVXEvent : AsyncPSCmdlet {
         } else if (ParameterSetName == "PathEvents") {
             // Handle file path queries
             if (Expand == false) {
-                foreach (var eventObject in SearchEvents.QueryLogFile(Path, EventId, ProviderName, Keywords, Level, StartTime, EndTime, UserId, MaxEvents, null, TimePeriod, Oldest, NamedDataFilter, NamedDataExcludeFilter, CancelToken)) {
+                foreach (var eventObject in SearchEvents.QueryLogFile(Path, EventId, ProviderName, Keywords, Level, StartTime, EndTime, UserId, MaxEvents, null, null, null, TimePeriod, Oldest, NamedDataFilter, NamedDataExcludeFilter, CancelToken)) {
                     if (!MessageMatches(eventObject)) {
                         continue;
                     }
@@ -234,7 +234,7 @@ public sealed class CmdletGetEVXEvent : AsyncPSCmdlet {
                     }
                 }
             } else {
-                foreach (var eventObject in SearchEvents.QueryLogFile(Path, EventId, ProviderName, Keywords, Level, StartTime, EndTime, UserId, MaxEvents, null, TimePeriod, Oldest, NamedDataFilter, NamedDataExcludeFilter, CancelToken)) {
+                foreach (var eventObject in SearchEvents.QueryLogFile(Path, EventId, ProviderName, Keywords, Level, StartTime, EndTime, UserId, MaxEvents, null, null, null, TimePeriod, Oldest, NamedDataFilter, NamedDataExcludeFilter, CancelToken)) {
                     if (!MessageMatches(eventObject)) {
                         continue;
                     }

--- a/Sources/PSEventViewer/CmdletGetEVXFilter.cs
+++ b/Sources/PSEventViewer/CmdletGetEVXFilter.cs
@@ -107,6 +107,8 @@ public sealed class CmdletGetEVXFilter : AsyncPSCmdlet {
         var output = SearchEvents.BuildWinEventFilter(
             ID,
             EventRecordID,
+            null,
+            null,
             StartTime,
             EndTime,
             Data,


### PR DESCRIPTION
## Summary
- support record id ranges when querying log files
- update filter generation for record id ranges
- include record id range defaults in cmdlets

## Testing
- `dotnet build Sources/EventViewerX.sln`
- `dotnet test Sources/EventViewerX.sln`


------
https://chatgpt.com/codex/tasks/task_e_686595cebf6c832e81a35da780eb2655