### PR TITLE
Add keyword filter support

### DIFF
--- a/Sources/EventViewerX/SearchEvents.QueryLog.cs
+++ b/Sources/EventViewerX/SearchEvents.QueryLog.cs
@@ -298,7 +298,7 @@ public partial class SearchEvents : Settings {
 
         // Add keywords to the query
         if (keywords.HasValue) {
-            AddCondition(queryString, $"Keywords={(long)keywords.Value}");
+            AddCondition(queryString, $"band(Keywords,{(long)keywords.Value})");
         }
 
         // Add level to the query

--- a/Tests/Get-EVXFilter.Tests.ps1
+++ b/Tests/Get-EVXFilter.Tests.ps1
@@ -39,4 +39,14 @@ Describe 'Additional Get-WinEventFilter cases' {
         $XPath = Get-EVXFilter -ExcludeID 1,2 -LogName 'xx' -XPathOnly
         $XPath | Should -Be '*[System[(EventID!=1) or (EventID!=2)]]'
     }
+
+    It '-Keywords single value should produce band filter' {
+        $XPath = Get-EVXFilter -Keywords 1125899906842624 -LogName 'xx' -XPathOnly
+        $XPath | Should -Be '*[System[band(Keywords,1125899906842624)]]'
+    }
+
+    It '-Keywords multiple values should OR them in band filter' {
+        $XPath = Get-EVXFilter -Keywords 1125899906842624,281474976710656 -LogName 'xx' -XPathOnly
+        $XPath | Should -Be '*[System[band(Keywords,1407374883553280)]]'
+    }
 }

--- a/Tests/Get-EVXFilter1.Tests.ps1
+++ b/Tests/Get-EVXFilter1.Tests.ps1
@@ -29,4 +29,14 @@ Describe "Get-EventFilters using Path and NamendDataFilter" {
         $XML | Should -BeLike '*Query Id="0" Path="file://*'    -Because 'We wanted to query a filepath'
         $XML | Should -Not -Belike '*Select Path*'              -Because 'Queries using eventfiles do not have a Channel'
     }
+
+    It '-Keywords single value should produce band filter' {
+        $XPath = Get-EVXFilter -Keywords 1125899906842624 -LogName 'xx' -XPathOnly
+        $XPath | Should -Be '*[System[band(Keywords,1125899906842624)]]'
+    }
+
+    It '-Keywords multiple values should OR them in band filter' {
+        $XPath = Get-EVXFilter -Keywords 1125899906842624,281474976710656 -LogName 'xx' -XPathOnly
+        $XPath | Should -Be '*[System[band(Keywords,1407374883553280)]]'
+    }
 }


### PR DESCRIPTION
## Summary
- add keyword bit filter logic for query strings
- test keyword filters

## Testing
- `pwsh -NoLogo -NoProfile -Command ./PSEventViewer.Tests.ps1` *(fails: Install-Package: No match was found)*
- `dotnet build Sources/EventViewerX/EventViewerX.csproj --no-restore`
- `dotnet build Sources/PSEventViewer/PSEventViewer.csproj --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_68663f68cf08832e94b3ec53627e7f00