### PR TITLE
Fix watcher ID handling

### DIFF
--- a/Sources/EventViewerX.Tests/TestWatchEvents.cs
+++ b/Sources/EventViewerX.Tests/TestWatchEvents.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Reflection;
+using Xunit;
+
+namespace EventViewerX.Tests {
+    public class TestWatchEvents {
+        private static ConcurrentBag<int> GetIds(WatchEvents watcher) {
+            var field = typeof(WatchEvents).GetField("_watchEventId", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(field);
+            return (ConcurrentBag<int>)field!.GetValue(watcher)!;
+        }
+
+        [Fact]
+        public void DisposeClearsWatchEventIds() {
+            var watcher = new WatchEvents();
+            watcher.Watch(Environment.MachineName, "Application", new List<int> { 1 });
+            watcher.Dispose();
+            var ids = GetIds(watcher);
+            Assert.Empty(ids);
+        }
+
+        [Fact]
+        public void SubsequentWatchesUseNewIdsOnly() {
+            var watcher = new WatchEvents();
+            watcher.Watch(Environment.MachineName, "Application", new List<int> { 1 });
+            watcher.Watch(Environment.MachineName, "Application", new List<int> { 2 });
+            var ids = GetIds(watcher);
+            Assert.DoesNotContain(1, ids);
+            Assert.Contains(2, ids);
+        }
+    }
+}

--- a/Sources/EventViewerX/WatchEvents.cs
+++ b/Sources/EventViewerX/WatchEvents.cs
@@ -83,6 +83,7 @@ namespace EventViewerX {
                 _eventLogWatcher.Dispose();
                 _eventLogWatcher = null;
             }
+            _watchEventId = new ConcurrentBag<int>();
             _eventLogSession?.Dispose();
             _eventLogSession = null;
         }


### PR DESCRIPTION
## Summary
- clear `_watchEventId` when disposing the watcher
- test that dispose empties IDs
- test that a second watch uses new IDs

## Testing
- `dotnet test Sources/EventViewerX.sln`

------
https://chatgpt.com/codex/tasks/task_e_68663f26b244832e93a22731683e6758