### PR TITLE
Fix query filter formatting

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -2,6 +2,7 @@
 
 #### 2.3.0 - 2024.11.25 *EXPERIMENTAL*
 - Fix for SMBv1
+- `BuildWinEventFilter` adds newlines between clauses for easier debugging when `xpathOnly` is `$false`
 
 **Full Changelog**: https://github.com/EvotecIT/PSEventViewer/compare/v2.2.0...v2.3.0
 

--- a/README.md
+++ b/README.md
@@ -64,3 +64,8 @@ Our module tries to improve on that by providing a bit more flexibility and spee
 ```powershell
 Get-EVXEvent -LogName Security -RecordIdFile C:\Temp\evx.state -RecordIdKey Machine1
 ```
+
+### Debugging query strings
+
+`BuildWinEventFilter` now inserts a newline between each query clause when `xpathOnly` is set to `$false`.
+The additional line breaks make complex XML queries easier to read in logs or debug output.

--- a/Sources/EventViewerX.Tests/TestWinEventFilter.cs
+++ b/Sources/EventViewerX.Tests/TestWinEventFilter.cs
@@ -64,7 +64,7 @@ namespace EventViewerX.Tests {
         public void IdMultipleValuesXmlQuery() {
             var result = SearchEvents.BuildWinEventFilter(id: ["1", "2"], logName: "Log");
             Assert.StartsWith("<QueryList>", result);
-            Assert.Contains("(EventID=1) or (EventID=2)", result);
+            Assert.Contains("(EventID=1) or\n(EventID=2)", result);
         }
 
         [Fact]

--- a/Sources/EventViewerX/SearchEvents.WinEventFilter.cs
+++ b/Sources/EventViewerX/SearchEvents.WinEventFilter.cs
@@ -148,6 +148,10 @@ public partial class SearchEvents {
             filter = JoinXPathFilter(InitializeXPathFilter(items, "{0}", "*[EventData[{0}]]", escapeItems: false), filter);
         }
 
+        if (!xpathOnly && !string.IsNullOrEmpty(filter)) {
+            filter = filter.Replace(" and ", " and\n").Replace(" or ", " or\n");
+        }
+
         if (xpathOnly) {
             return filter;
         }


### PR DESCRIPTION
## Summary
- output multi-line XML filters for easier debugging
- document the new formatting
- adjust tests for newlines

## Testing
- `dotnet test Sources/EventViewerX.sln`

------
https://chatgpt.com/codex/tasks/task_e_68663f310898832e91136042344e85b4