### PR TITLE
Add SQL database creation rule

### DIFF
--- a/Sources/EventViewerX/Enums/NamedEvents.cs
+++ b/Sources/EventViewerX/Enums/NamedEvents.cs
@@ -316,5 +316,10 @@
         /// DFS Replication partner error
         /// </summary>
         DfsReplicationError,
+
+        /// <summary>
+        /// SQL Server database created
+        /// </summary>
+        SqlDatabaseCreated,
     }
 }

--- a/Sources/EventViewerX/Rules/SQL/SqlDatabaseCreated.cs
+++ b/Sources/EventViewerX/Rules/SQL/SqlDatabaseCreated.cs
@@ -1,0 +1,34 @@
+namespace EventViewerX.Rules.SQL;
+
+/// <summary>
+/// SQL Server database created
+/// 17137: Starting up database
+/// 1802: CREATE DATABASE succeeded
+/// </summary>
+public class SqlDatabaseCreated : EventRuleBase {
+    public override List<int> EventIds => new() { 17137, 1802 };
+    public override string LogName => "Application";
+    public override NamedEvents NamedEvent => NamedEvents.SqlDatabaseCreated;
+
+    public override bool CanHandle(EventObject eventObject) {
+        // Simple rule - always handle if event ID and log name match
+        return true;
+    }
+
+    public string Computer;
+    public string DatabaseName;
+    public DateTime When;
+
+    public SqlDatabaseCreated(EventObject eventObject) : base(eventObject) {
+        _eventObject = eventObject;
+        Type = "SqlDatabaseCreated";
+        Computer = _eventObject.ComputerName;
+        DatabaseName = _eventObject.GetValueFromDataDictionary("Database", "Database Name");
+        if (string.IsNullOrEmpty(DatabaseName)) {
+            var match = System.Text.RegularExpressions.Regex.Match(_eventObject.Message ?? string.Empty,
+                "database ['\"]?(?<db>[^'\"]+)['\"]?", System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+            DatabaseName = match.Success ? match.Groups["db"].Value : string.Empty;
+        }
+        When = _eventObject.TimeCreated;
+    }
+}


### PR DESCRIPTION
## Summary
- add `SqlDatabaseCreated` rule monitoring Application log
- extend `NamedEvents` enum for SQL database creation

## Testing
- `dotnet build Sources/EventViewerX.sln -c Release`
- `dotnet test Sources/EventViewerX.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68663efa62ac832eb6acb8e1263028df