### PR TITLE
Add staging support for event ID 350

### DIFF
--- a/Sources/EventViewerX.Tests/TestWatchEvents.cs
+++ b/Sources/EventViewerX.Tests/TestWatchEvents.cs
@@ -30,5 +30,14 @@ namespace EventViewerX.Tests {
             Assert.DoesNotContain(1, ids);
             Assert.Contains(2, ids);
         }
+
+        [Fact]
+        public void StagingAddsEvent350AndRecordsUser() {
+            var watcher = new WatchEvents();
+            watcher.Watch(Environment.MachineName, "Application", new List<int> { 1 }, null, default, true, "tester");
+            var ids = GetIds(watcher);
+            Assert.Contains(350, ids);
+            Assert.Equal("tester", watcher.StagingEnabledBy);
+        }
     }
 }

--- a/Sources/EventViewerX/WatchEvents.cs
+++ b/Sources/EventViewerX/WatchEvents.cs
@@ -14,6 +14,16 @@ namespace EventViewerX {
         private ConcurrentBag<int> _watchEventId = new ConcurrentBag<int>();
 
         /// <summary>
+        /// Indicates whether staging is enabled.
+        /// </summary>
+        public bool StagingEnabled { get; private set; }
+
+        /// <summary>
+        /// Username of the account that enabled staging.
+        /// </summary>
+        public string StagingEnabledBy { get; private set; }
+
+        /// <summary>
         /// Action executed when an event matching the filter is detected.
         /// </summary>
         private Action<EventObject> _eventAction;
@@ -34,9 +44,17 @@ namespace EventViewerX {
             }
         }
 
-        public void Watch(string machineName, string logName, List<int> eventId, Action<EventObject> eventAction = null, CancellationToken cancellationToken = default) {
+        public void Watch(string machineName, string logName, List<int> eventId, Action<EventObject> eventAction = null, CancellationToken cancellationToken = default, bool staging = false, string enabledBy = null) {
             Dispose();
             _machineName = machineName;
+            if (staging && !eventId.Contains(350)) {
+                eventId.Add(350);
+                StagingEnabled = true;
+                StagingEnabledBy = enabledBy ?? Environment.UserName;
+            } else {
+                StagingEnabled = false;
+                StagingEnabledBy = null;
+            }
             _watchEventId = new ConcurrentBag<int>(eventId);
             _eventAction = eventAction;
             try {
@@ -84,6 +102,8 @@ namespace EventViewerX {
                 _eventLogWatcher = null;
             }
             _watchEventId = new ConcurrentBag<int>();
+            StagingEnabled = false;
+            StagingEnabledBy = null;
             _eventLogSession?.Dispose();
             _eventLogSession = null;
         }

--- a/Sources/PSEventViewer/CmdletStartEVXWatcher.cs
+++ b/Sources/PSEventViewer/CmdletStartEVXWatcher.cs
@@ -33,6 +33,12 @@ namespace PSEventViewer {
         public int[] EventId { get; set; }
 
         /// <summary>
+        /// Enables staging mode which also watches for event ID 350.
+        /// </summary>
+        [Parameter(Mandatory = false)]
+        public SwitchParameter Staging { get; set; }
+
+        /// <summary>
         /// Script block executed when matching events are detected.
         /// </summary>
         [Parameter(Mandatory = true, Position = 3)]
@@ -62,7 +68,8 @@ namespace PSEventViewer {
         /// Starts watching for events and invokes the provided action.
         /// </summary>
         protected override Task ProcessRecordAsync() {
-            EventWatching.Watch(MachineName, LogName, EventId.ToList(), e => Action.Invoke(e), CancelToken);
+            var ids = EventId.ToList();
+            EventWatching.Watch(MachineName, LogName, ids, e => Action.Invoke(e), CancelToken, Staging.IsPresent, Environment.UserName);
             return Task.CompletedTask;
         }
         /// <summary>


### PR DESCRIPTION
## Summary
- add staging tracking to `WatchEvents`
- enable `-Staging` switch on `Start-EVXWatcher`
- test that event ID 350 is added when staging is enabled

## Testing
- `dotnet test Sources/EventViewerX.sln --no-build`
- `pwsh -NoLogo -NoProfile -File ./PSEventViewer.Tests.ps1` *(fails: `Write-Color` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68664d6a0520832e99b1f416ff75be3f