### PR TITLE
Add AAD Connect rule for event 906

### DIFF
--- a/Sources/EventViewerX/Enums/NamedEvents.cs
+++ b/Sources/EventViewerX/Enums/NamedEvents.cs
@@ -321,5 +321,10 @@
         /// SQL Server database created
         /// </summary>
         SqlDatabaseCreated,
+
+        /// <summary>
+        /// Azure AD Connect run profile completed
+        /// </summary>
+        AADConnectRunProfile,
     }
 }

--- a/Sources/EventViewerX/Rules/AADConnect/AADConnectRunProfile.cs
+++ b/Sources/EventViewerX/Rules/AADConnect/AADConnectRunProfile.cs
@@ -1,0 +1,28 @@
+namespace EventViewerX.Rules.AADConnect;
+
+/// <summary>
+/// Azure AD Connect run profile completed
+/// 906: The run profile finished executing
+/// </summary>
+public class AADConnectRunProfile : EventRuleBase {
+    public override List<int> EventIds => new() { 906 };
+    public override string LogName => "Application";
+    public override NamedEvents NamedEvent => NamedEvents.AADConnectRunProfile;
+
+    public override bool CanHandle(EventObject eventObject) {
+        // Simple rule - always handle if event ID and log name match
+        return true;
+    }
+
+    public string Connector;
+    public string RunProfile;
+    public DateTime When;
+
+    public AADConnectRunProfile(EventObject eventObject) : base(eventObject) {
+        _eventObject = eventObject;
+        Type = "AADConnectRunProfile";
+        Connector = _eventObject.GetValueFromDataDictionary("Connector", "Connector Name");
+        RunProfile = _eventObject.GetValueFromDataDictionary("RunProfileName", "Run Profile Name", "", false);
+        When = _eventObject.TimeCreated;
+    }
+}


### PR DESCRIPTION
## Summary
- support AAD Connect event ID 906
- output connector name and run profile for the event

## Testing
- `dotnet build Sources/EventViewerX/EventViewerX.csproj -c Release`
- `dotnet build Sources/PSEventViewer/PSEventViewer.csproj -c Release`
- `dotnet test Sources/EventViewerX.Tests/EventViewerX.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68664d702c1c832e8b6e485f08a719f7