### PR TITLE
Add SyncCompleted event rule

### DIFF
--- a/Sources/EventViewerX/Enums/NamedEvents.cs
+++ b/Sources/EventViewerX/Enums/NamedEvents.cs
@@ -321,5 +321,10 @@
         /// SQL Server database created
         /// </summary>
         SqlDatabaseCreated,
+
+        /// <summary>
+        /// Synchronization finished successfully
+        /// </summary>
+        SyncCompleted,
     }
 }

--- a/Sources/EventViewerX/Rules/Windows/SyncCompleted.cs
+++ b/Sources/EventViewerX/Rules/Windows/SyncCompleted.cs
@@ -1,0 +1,32 @@
+namespace EventViewerX.Rules.Windows;
+
+/// <summary>
+/// Sync process ended event
+/// 907: Synchronization completed
+/// </summary>
+public class SyncCompleted : EventRuleBase {
+    public override List<int> EventIds => new() { 907 };
+    public override string LogName => "Application";
+    public override NamedEvents NamedEvent => NamedEvents.SyncCompleted;
+
+    public override bool CanHandle(EventObject eventObject) => true;
+
+    public string Computer;
+    public DateTime When;
+    public Dictionary<string, int> Statistics = new();
+
+    public SyncCompleted(EventObject eventObject) : base(eventObject) {
+        _eventObject = eventObject;
+        Type = "SyncCompleted";
+        Computer = _eventObject.ComputerName;
+        When = _eventObject.TimeCreated;
+
+        var matches = System.Text.RegularExpressions.Regex.Matches(_eventObject.Message ?? string.Empty, @"(\w+):\s*(\d+)");
+        foreach (System.Text.RegularExpressions.Match match in matches) {
+            var key = match.Groups[1].Value;
+            if (int.TryParse(match.Groups[2].Value, out var val)) {
+                Statistics[key] = val;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add new `SyncCompleted` rule to detect Event ID 907
- expose statistics from the log when sync completes

## Testing
- `dotnet test Sources/EventViewerX.Tests/EventViewerX.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68664d7457bc832e80f8bfa5675d4f3b