### PR TITLE
Monitor password sync failures

### DIFF
--- a/Examples/Example.PasswordSyncFailedCount.ps1
+++ b/Examples/Example.PasswordSyncFailedCount.ps1
@@ -1,0 +1,10 @@
+# Example: Monitor password synchronization failures (event ID 611)
+# Displays the number of affected users in the specified time range.
+
+Import-Module $PSScriptRoot\..\PSEventViewer.psd1 -Force
+
+$events = Get-EVXEvent -Machine $env:COMPUTERNAME -LogName 'Application' -ID 611 -Expand
+
+$users = $events | ForEach-Object { $_.GetValueFromDataDictionary('User', 'AccountName') }
+$uniqueUsers = $users | Where-Object { $_ } | Sort-Object -Unique
+"Failed password sync user count: $($uniqueUsers.Count)"

--- a/Sources/EventViewerX/Enums/NamedEvents.cs
+++ b/Sources/EventViewerX/Enums/NamedEvents.cs
@@ -321,5 +321,10 @@
         /// SQL Server database created
         /// </summary>
         SqlDatabaseCreated,
+
+        /// <summary>
+        /// Password synchronization failure
+        /// </summary>
+        PasswordSyncFailed,
     }
 }

--- a/Sources/EventViewerX/Rules/ActiveDirectory/PasswordSyncFailed.cs
+++ b/Sources/EventViewerX/Rules/ActiveDirectory/PasswordSyncFailed.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+
+namespace EventViewerX.Rules.ActiveDirectory;
+
+/// <summary>
+/// Password synchronization failed
+/// Event ID 611: Failed password synchronization
+/// </summary>
+public class PasswordSyncFailed : EventRuleBase {
+    public override List<int> EventIds => new() { 611 };
+    public override string LogName => "Application";
+    public override NamedEvents NamedEvent => NamedEvents.PasswordSyncFailed;
+
+    public override bool CanHandle(EventObject eventObject) {
+        return true;
+    }
+
+    public string Computer;
+    public string User;
+    public string Error;
+    public DateTime When;
+
+    public PasswordSyncFailed(EventObject eventObject) : base(eventObject) {
+        _eventObject = eventObject;
+        Type = "PasswordSyncFailed";
+        Computer = _eventObject.ComputerName;
+        User = _eventObject.GetValueFromDataDictionary("User", "AccountName");
+        Error = _eventObject.GetValueFromDataDictionary("ErrorCode", "FailureCode");
+        When = _eventObject.TimeCreated;
+        if (string.IsNullOrEmpty(User)) {
+            ParseMessage(_eventObject.Message);
+        }
+    }
+
+    private void ParseMessage(string message) {
+        if (string.IsNullOrEmpty(message)) return;
+        var match = System.Text.RegularExpressions.Regex.Match(message, "user:?\\s*(?<user>[^\\s'\\\"]+)");
+        if (match.Success) {
+            User = match.Groups["user"].Value;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `PasswordSyncFailed` named event
- implement rule for event ID 611 to detect password sync failures
- add example script to count affected users

## Testing
- `dotnet build Sources/EventViewerX/EventViewerX.csproj -c Release`
- `dotnet build Sources/PSEventViewer/PSEventViewer.csproj -c Release`
- `pwsh -NoLogo -NoProfile -Command ./PSEventViewer.Tests.ps1` *(fails: Write-Color not found)*

------
https://chatgpt.com/codex/tasks/task_e_68664d7811a4832eb5fb2c441e7ee00f