### PR TITLE
Fix negative diff values

### DIFF
--- a/Sources/EventViewerX.Tests/TestWinEventFilter.cs
+++ b/Sources/EventViewerX.Tests/TestWinEventFilter.cs
@@ -76,5 +76,19 @@ namespace EventViewerX.Tests {
             Assert.Contains("TimeCreated[timediff(@SystemTime) &gt;=", result);
             Assert.DoesNotContain("<QueryList>", result);
         }
+
+        [Fact]
+        public void FutureStartTimeIsClamped() {
+            var start = DateTime.Now.AddMinutes(10);
+            var result = SearchEvents.BuildWinEventFilter(startTime: start, logName: "x", xpathOnly: true);
+            Assert.Contains("timediff(@SystemTime) &lt;= 0", result);
+        }
+
+        [Fact]
+        public void FutureEndTimeIsClamped() {
+            var end = DateTime.Now.AddMinutes(5);
+            var result = SearchEvents.BuildWinEventFilter(endTime: end, logName: "x", xpathOnly: true);
+            Assert.Contains("timediff(@SystemTime) &gt;= 0", result);
+        }
     }
 }

--- a/Sources/EventViewerX/SearchEvents.WinEventFilter.cs
+++ b/Sources/EventViewerX/SearchEvents.WinEventFilter.cs
@@ -73,10 +73,16 @@ public partial class SearchEvents {
         var now = DateTime.Now;
         if (startTime.HasValue) {
             var diff = Math.Round(now.Subtract(startTime.Value).TotalMilliseconds);
+            if (diff < 0) {
+                diff = 0;
+            }
             filter = JoinXPathFilter($"*[System[TimeCreated[timediff(@SystemTime) &lt;= {diff}]]]", filter);
         }
         if (endTime.HasValue) {
             var diff = Math.Round(now.Subtract(endTime.Value).TotalMilliseconds);
+            if (diff < 0) {
+                diff = 0;
+            }
             filter = JoinXPathFilter($"*[System[TimeCreated[timediff(@SystemTime) &gt;= {diff}]]]", filter);
         }
         if (data != null && data.Length > 0) {


### PR DESCRIPTION
## Summary
- clamp negative diff values when calculating event time ranges
- test future start/end time handling

## Testing
- `dotnet build Sources/EventViewerX.sln` *(fails: unable to restore packages)*
- `dotnet test Sources/EventViewerX.sln --no-restore` *(fails: unable to resolve packages)*

------
https://chatgpt.com/codex/tasks/task_e_68665777f5f4832e8865620a42e419ee