### PR TITLE
Sanitize QueryLogFile path input

### DIFF
--- a/Sources/EventViewerX.Tests/TestQueryLogFile.cs
+++ b/Sources/EventViewerX.Tests/TestQueryLogFile.cs
@@ -1,0 +1,17 @@
+using System;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace EventViewerX.Tests {
+    public class TestQueryLogFile {
+        [Fact]
+        public void QueryLogFileSanitizesPath() {
+            if (!OperatingSystem.IsWindows()) return;
+            string path = Path.Combine("..", "..", "..", "..", "..", "Tests", "Logs", "Active Directory Web Services.evtx");
+            string quotedPath = $"\"{path}\"";
+            var events = SearchEvents.QueryLogFile(quotedPath).ToList();
+            Assert.NotEmpty(events);
+        }
+    }
+}

--- a/Sources/EventViewerX/SearchEvents.QueryLog.cs
+++ b/Sources/EventViewerX/SearchEvents.QueryLog.cs
@@ -78,7 +78,10 @@ public partial class SearchEvents : Settings {
     /// <returns>An enumerable collection of EventObject instances representing the filtered events from the log file.</returns>
     public static IEnumerable<EventObject> QueryLogFile(string filePath, List<int> eventIds = null, string providerName = null, Keywords? keywords = null, Level? level = null, DateTime? startTime = null, DateTime? endTime = null, string userId = null, int maxEvents = 0, List<long> eventRecordId = null, TimePeriod? timePeriod = null, bool oldest = false, System.Collections.Hashtable namedDataFilter = null, System.Collections.Hashtable namedDataExcludeFilter = null, CancellationToken cancellationToken = default) {
 
-        string absolutePath = Path.GetFullPath(filePath);
+        // Sanitize the provided path in case it contains wrapping quotes or extra spaces
+        string sanitizedPath = filePath.Trim().Trim('"', '\'');
+
+        string absolutePath = Path.GetFullPath(sanitizedPath);
 
         if (!File.Exists(absolutePath)) {
             throw new FileNotFoundException($"The log file '{absolutePath}' does not exist.", absolutePath);


### PR DESCRIPTION
## Summary
- sanitize the `filePath` argument in `QueryLogFile`
- add a unit test for paths with spaces or quotes

## Testing
- `dotnet build Sources/EventViewerX.sln -c Release`
- `dotnet test Sources/EventViewerX.sln -c Release --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68665780f728832e96c08dda788b9d5b