### PR TITLE
Reset event counter on new watch

### DIFF
--- a/Sources/EventViewerX.Tests/TestWatchEvents.cs
+++ b/Sources/EventViewerX.Tests/TestWatchEvents.cs
@@ -39,5 +39,13 @@ namespace EventViewerX.Tests {
             Assert.Contains(350, ids);
             Assert.Equal("tester", watcher.StagingEnabledBy);
         }
+
+        [Fact]
+        public void WatchResetsNumberOfEventsFound() {
+            WatchEvents.NumberOfEventsFound = 5;
+            var watcher = new WatchEvents();
+            watcher.Watch(Environment.MachineName, "Application", new List<int> { 1 });
+            Assert.Equal(0, WatchEvents.NumberOfEventsFound);
+        }
     }
 }

--- a/Sources/EventViewerX/WatchEvents.cs
+++ b/Sources/EventViewerX/WatchEvents.cs
@@ -45,6 +45,7 @@ namespace EventViewerX {
         }
 
         public void Watch(string machineName, string logName, List<int> eventId, Action<EventObject> eventAction = null, CancellationToken cancellationToken = default, bool staging = false, string enabledBy = null) {
+            NumberOfEventsFound = 0;
             Dispose();
             _machineName = machineName;
             if (staging && !eventId.Contains(350)) {


### PR DESCRIPTION
## Summary
- reset `NumberOfEventsFound` every time `Watch` starts
- ensure the count resets with a regression test

## Testing
- `dotnet restore` *(fails: xunit.runner.visualstudio 503)*
- `dotnet build` *(fails: missing .NETFramework reference assemblies)*
- `dotnet test` *(fails: argument invalid)*

------
https://chatgpt.com/codex/tasks/task_e_686657884cdc832e9df71bb4de5425c2