### PR TITLE
Add watcher management cmdlets

### DIFF
--- a/Examples/Example.StartWatcherAdvanced.ps1
+++ b/Examples/Example.StartWatcherAdvanced.ps1
@@ -1,0 +1,12 @@
+Clear-Host
+Import-Module $PSScriptRoot\..\PSEventViewer.psd1 -Force
+
+# Start watcher for application errors
+Start-EVXWatcher -MachineName $env:COMPUTERNAME -LogName 'Application' -EventId 1000 -Action {
+    Write-Host "Application error: $($_.Message)"
+}
+
+# Start watcher for service crashes with additional stop conditions
+Start-EVXWatcher -MachineName $env:COMPUTERNAME -LogName 'System' -EventId 7031 -StopAfter 5 -Until { $_.Id -eq 7031 } -Action {
+    Write-Host "Service crashed: $($_.Properties[0].Value)"
+}

--- a/Examples/Example.StartWatcherSimple.ps1
+++ b/Examples/Example.StartWatcherSimple.ps1
@@ -1,0 +1,6 @@
+Clear-Host
+Import-Module $PSScriptRoot\..\PSEventViewer.psd1 -Force
+
+Start-EVXWatcher -MachineName $env:COMPUTERNAME -LogName 'Application' -EventId 1 -TimeoutSeconds 30 -StopOnMatch -Action {
+    Write-Host "Application event triggered: $($_.Id)"
+}

--- a/Examples/Example.WatcherStopConditions.ps1
+++ b/Examples/Example.WatcherStopConditions.ps1
@@ -1,0 +1,7 @@
+Clear-Host
+Import-Module $PSScriptRoot\..\PSEventViewer.psd1 -Force
+
+# Start watcher directly with multiple stop options
+Start-EVXWatcher -MachineName $env:COMPUTERNAME -LogName 'Application' -EventId 1000 -TimeoutSeconds 300 -StopAfter 2 -Until { $_.Source -eq 'Application Error' } -Action {
+    Write-Host "Error event: $($_.Message)"
+}

--- a/PSEventViewer.psd1
+++ b/PSEventViewer.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport      = @('Get-EventViewerXEvent', 'Find-WinEvent', 'Get-Events', 'Get-EventViewerXFilter', 'Get-WinEventFilter', 'Get-EventsFilter', 'Get-EventViewerXInfo', 'Get-EventsSettings', 'Get-EventsInformation', 'Restore-EVXPowerShellScript', 'Get-PowerShellScriptExecution', 'Restore-PowerShellScript', 'Get-EventViewerXProviderList', 'Remove-EventViewerXSource', 'Remove-WinEventSource', 'Set-EventViewerXInfo', 'Set-EventsInformation', 'Set-EventsSettings', 'Start-EventViewerXWatcher', 'Start-EventWatching', 'Write-EventViewerXEntry', 'Write-WinEvent')
     Author               = 'Przemyslaw Klys'
-    CmdletsToExport      = @('Get-EVXEvent', 'Get-EVXFilter', 'Get-EVXInfo', 'Get-EVXPowerShellScript', 'Get-EVXProviderList', 'Remove-EVXSource', 'Set-EVXInfo', 'Start-EVXWatcher', 'Write-EVXEntry')
+    CmdletsToExport      = @('Get-EVXEvent', 'Get-EVXFilter', 'Get-EVXInfo', 'Get-EVXPowerShellScript', 'Get-EVXProviderList', 'Remove-EVXSource', 'Set-EVXInfo', 'Start-EVXWatcher', 'Register-EVXWatcher', 'Get-EVXWatcher', 'Remove-EVXWatcher', 'Write-EVXEntry')
     CompanyName          = 'Evotec'
     CompatiblePSEditions = @('Desktop', 'Core')
     Copyright            = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'

--- a/PSEventViewer.psm1
+++ b/PSEventViewer.psm1
@@ -7,6 +7,7 @@ $BinaryModules = @(
     "PSEventViewer.dll"
 )
 
+
 # Get public and private function definition files.
 $Public = @( Get-ChildItem -Path $PSScriptRoot\Public\*.ps1 -ErrorAction SilentlyContinue -Recurse -File)
 $Private = @( Get-ChildItem -Path $PSScriptRoot\Private\*.ps1 -ErrorAction SilentlyContinue -Recurse -File)

--- a/README.md
+++ b/README.md
@@ -55,4 +55,37 @@ Our module tries to improve on that by providing a bit more flexibility and spee
 - [Documentation for PSEventViewer (examples and how things are different)](https://evotec.xyz/working-with-windows-events-with-powershell/)
 - [PowerShell - Everything you wanted to know about Event Logs and then some](https://evotec.xyz/powershell-everything-you-wanted-to-know-about-event-logs/)
 - [Sending information to Event Log with extended fields using PowerShell](https://evotec.xyz/sending-information-to-event-log-with-extended-fields-using-powershell/)
-- [The only PowerShell Command you will ever need to find out who did what in Active Directory](https://evotec.xyz/the-only-powershell-command-you-will-ever-need-to-find-out-who-did-what-in-active-directory/)
+ - [The only PowerShell Command you will ever need to find out who did what in Active Directory](https://evotec.xyz/the-only-powershell-command-you-will-ever-need-to-find-out-who-did-what-in-active-directory/)
+
+## Real-time Event Watching
+
+`Register-EVXWatcher` stores a watcher definition for later use, while `Start-EVXWatcher` can start a watcher directly or by name.
+
+```powershell
+# register and run later
+Register-EVXWatcher -Name 'AppErrors' -MachineName $env:COMPUTERNAME -LogName 'Application' -EventId 1000 -Action {
+    Write-Host "Application error: $($_.Message)"
+}
+
+# start by name and capture watcher id
+$id = Start-EVXWatcher -Name 'AppErrors'
+
+# or run immediately without registration
+Start-EVXWatcher -MachineName $env:COMPUTERNAME -LogName 'Application' -EventId 1000 -Action {
+    Write-Host "Application error: $($_.Message)"
+}
+```
+
+Use `Get-EVXWatcher -Running` to list active watchers and `Remove-EVXWatcher -Name $id` to stop them.
+
+It supports automatic stop conditions:
+
+- `-TimeoutSeconds` – stop after a period of time
+- `-StopOnMatch` – stop when the first matching event is found
+- `-StopAfter` – stop after a given number of matches
+- `-Until` – script block evaluated for each event and stopping when it returns `$true`
+
+Additional sample scripts are available in the `Examples` directory, including:
+- Example.StartWatcherSimple.ps1
+- Example.StartWatcherAdvanced.ps1
+- Example.WatcherStopConditions.ps1

--- a/Sources/PSEventViewer/CmdletGetEVXWatcher.cs
+++ b/Sources/PSEventViewer/CmdletGetEVXWatcher.cs
@@ -1,0 +1,32 @@
+using System.Linq;
+using System.Management.Automation;
+
+namespace PSEventViewer {
+    /// <summary>
+    /// Returns information about registered or running watchers.
+    /// </summary>
+    [Cmdlet(VerbsCommon.Get, "EVXWatcher")]
+    [OutputType(typeof(WatcherSettings))]
+    public sealed class CmdletGetEVXWatcher : PSCmdlet {
+        [Parameter]
+        public SwitchParameter Running { get; set; }
+
+        protected override void ProcessRecord() {
+            if (Running.IsPresent) {
+                foreach (var kvp in WatcherRegistry.GetRunning().ToArray()) {
+                    WriteObject(new {
+                        Name = kvp.Key,
+                        kvp.Value.Definition.MachineName,
+                        kvp.Value.Definition.LogName,
+                        kvp.Value.Definition.EventId,
+                        kvp.Value.Started
+                    });
+                }
+            } else {
+                foreach (var def in WatcherRegistry.GetAllDefinitions()) {
+                    WriteObject(def);
+                }
+            }
+        }
+    }
+}

--- a/Sources/PSEventViewer/CmdletRegisterEVXWatcher.cs
+++ b/Sources/PSEventViewer/CmdletRegisterEVXWatcher.cs
@@ -1,0 +1,41 @@
+using System.Management.Automation;
+
+namespace PSEventViewer {
+    /// <summary>
+    /// Stores watcher definitions in the global registry for later starting.
+    /// </summary>
+    [Cmdlet(VerbsLifecycle.Register, "EVXWatcher")]
+    [OutputType(typeof(void))]
+    public sealed class CmdletRegisterEVXWatcher : PSCmdlet {
+        [Parameter(Mandatory = true, Position = 0)]
+        public string Name { get; set; }
+
+        [Parameter(Mandatory = true)]
+        public string MachineName { get; set; }
+
+        [Parameter(Mandatory = true)]
+        public string LogName { get; set; }
+
+        [Parameter(Mandatory = true)]
+        public int[] EventId { get; set; }
+
+        [Parameter(Mandatory = true)]
+        public ScriptBlock Action { get; set; }
+
+        [Parameter]
+        [ValidateRange(1, 1024)]
+        public int NumberOfThreads { get; set; } = 8;
+
+        protected override void ProcessRecord() {
+            var def = new WatcherSettings {
+                Name = Name,
+                MachineName = MachineName,
+                LogName = LogName,
+                EventId = EventId,
+                Action = Action,
+                NumberOfThreads = NumberOfThreads
+            };
+            WatcherRegistry.Register(def);
+        }
+    }
+}

--- a/Sources/PSEventViewer/CmdletRemoveEVXWatcher.cs
+++ b/Sources/PSEventViewer/CmdletRemoveEVXWatcher.cs
@@ -1,0 +1,26 @@
+using System.Management.Automation;
+
+namespace PSEventViewer {
+    /// <summary>
+    /// Stops a running watcher and removes it from the registry.
+    /// </summary>
+    [Cmdlet(VerbsCommon.Remove, "EVXWatcher", SupportsShouldProcess = true)]
+    [OutputType(typeof(bool))]
+    public sealed class CmdletRemoveEVXWatcher : PSCmdlet {
+        [Parameter(Mandatory = true, Position = 0)]
+        public string Name { get; set; }
+
+        [Parameter]
+        public SwitchParameter DefinitionOnly { get; set; }
+
+        protected override void ProcessRecord() {
+            bool result = false;
+            if (DefinitionOnly.IsPresent) {
+                result = WatcherRegistry.RemoveDefinition(Name);
+            } else {
+                result = WatcherRegistry.Stop(Name) || WatcherRegistry.RemoveDefinition(Name);
+            }
+            WriteObject(result);
+        }
+    }
+}

--- a/Sources/PSEventViewer/CmdletStartEVXWatcher.cs
+++ b/Sources/PSEventViewer/CmdletStartEVXWatcher.cs
@@ -1,68 +1,120 @@
 ﻿using EventViewerX;
+using System;
 using System.Management.Automation;
 using System.Threading.Tasks;
 using System.Linq;
+using System.Threading;
 
 namespace PSEventViewer {
     /// <summary>
     /// Starts real-time monitoring of Windows Event Logs with customizable filters and actions.
     /// Provides continuous event watching with scriptblock execution for matched events.
     /// </summary>
-    [Cmdlet(VerbsLifecycle.Start, "EVXWatcher")]
+    [Cmdlet(VerbsLifecycle.Start, "EVXWatcher", DefaultParameterSetName = "Direct")]
     [Alias("Start-EventViewerXWatcher", "Start-EventWatching")]
-    [OutputType(typeof(void))]
+    [OutputType(typeof(string))]
     public sealed class CmdletStartEVXWatcher : AsyncPSCmdlet {
-        private WatchEvents EventWatching { get; set; }
+        private InternalLogger _internalLogger;
+
+        private class WatcherDefinition {
+            public string Name { get; set; }
+            public string MachineName { get; set; }
+            public string LogName { get; set; }
+            public int[] EventId { get; set; }
+            public ScriptBlock Action { get; set; }
+            public int NumberOfThreads { get; set; }
+        }
+
+        [Parameter(ParameterSetName = "Registered", Mandatory = true, Position = 0)]
+        [Parameter(ParameterSetName = "Direct")]
+        public string Name { get; set; }
 
         /// <summary>
         /// Name of the computer to monitor events on.
         /// </summary>
-        [Parameter(Mandatory = true, Position = 0)]
+        [Parameter(Mandatory = true, Position = 0, ParameterSetName = "Direct")]
         public string MachineName { get; set; }
 
         /// <summary>
         /// Name of the log to watch on the specified machine.
         /// </summary>
-        [Parameter(Mandatory = true, Position = 1)]
+        [Parameter(Mandatory = true, Position = 1, ParameterSetName = "Direct")]
         public string LogName { get; set; }
 
         /// <summary>
         /// Array of event identifiers to monitor.
         /// </summary>
-        [Parameter(Mandatory = true, Position = 2)]
+        [Parameter(Mandatory = true, Position = 2, ParameterSetName = "Direct")]
         public int[] EventId { get; set; }
 
         /// <summary>
         /// Script block executed when matching events are detected.
         /// </summary>
-        [Parameter(Mandatory = true, Position = 3)]
+        [Parameter(Mandatory = true, Position = 3, ParameterSetName = "Direct")]
         public ScriptBlock Action { get; set; }
 
         /// <summary>
         /// Number of threads used for event processing.
         /// </summary>
-        [Parameter(Mandatory = false)]
+        [Parameter(ParameterSetName = "Direct")]
         [ValidateRange(1, 1024)]
         public int NumberOfThreads { get; set; } = 8;
+
+        [Parameter(ParameterSetName = "Direct")]
+        public int TimeoutSeconds { get; set; } = 0;
+
+        [Parameter(ParameterSetName = "Direct")]
+        public SwitchParameter StopOnMatch { get; set; }
+
+        [Parameter(ParameterSetName = "Direct")]
+        [ValidateRange(1, int.MaxValue)]
+        public int StopAfter { get; set; } = 0;
+
+        [Parameter(ParameterSetName = "Direct")]
+        public ScriptBlock Until { get; set; }
+
 
         /// <summary>
         /// Initializes resources prior to processing.
         /// </summary>
         protected override Task BeginProcessingAsync() {
-            // Initialize the logger to be able to see verbose, warning, debug, error, progress, and information messages.
-            var internalLogger = new InternalLogger(false);
-            var internalLoggerPowerShell = new InternalLoggerPowerShell(internalLogger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
-
-            EventWatching = new WatchEvents(internalLogger) {
-                NumberOfThreads = NumberOfThreads
-            };
+            _internalLogger = new InternalLogger(false);
             return Task.CompletedTask;
         }
         /// <summary>
         /// Starts watching for events and invokes the provided action.
         /// </summary>
+        private void StartWatcher(string runName, WatcherSettings settings) {
+            WatcherRegistry.Start(runName, _internalLogger, settings, TimeoutSeconds, StopOnMatch, StopAfter, Until, CancelToken);
+        }
+
         protected override Task ProcessRecordAsync() {
-            EventWatching.Watch(MachineName, LogName, EventId.ToList(), e => Action.Invoke(e), CancelToken);
+            WatcherSettings settings;
+            string runName = Name;
+
+            if (this.ParameterSetName == "Registered") {
+                if (!WatcherRegistry.TryGet(Name, out var def)) {
+                    WriteError(new ErrorRecord(new ItemNotFoundException($"Watcher '{Name}' not found"), "NotFound", ErrorCategory.ObjectNotFound, Name));
+                    return Task.CompletedTask;
+                }
+                settings = def;
+            } else {
+                settings = new WatcherSettings {
+                    Name = Name,
+                    MachineName = MachineName,
+                    LogName = LogName,
+                    EventId = EventId,
+                    Action = Action,
+                    NumberOfThreads = NumberOfThreads
+                };
+            }
+
+            if (string.IsNullOrEmpty(runName)) {
+                runName = Guid.NewGuid().ToString();
+            }
+
+            StartWatcher(runName, settings);
+            WriteObject(runName);
             return Task.CompletedTask;
         }
         /// <summary>

--- a/Sources/PSEventViewer/WatcherRegistry.cs
+++ b/Sources/PSEventViewer/WatcherRegistry.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Management.Automation;
+using System.Linq;
+using System.Threading;
+using EventViewerX;
+
+namespace PSEventViewer {
+    /// <summary>
+    /// Settings describing a watcher definition stored in the registry.
+    /// </summary>
+    public class WatcherSettings {
+        public string Name { get; set; }
+        public string MachineName { get; set; }
+        public string LogName { get; set; }
+        public int[] EventId { get; set; }
+        public ScriptBlock Action { get; set; }
+        public int NumberOfThreads { get; set; } = 8;
+    }
+
+    /// <summary>
+    /// Runtime information about a running watcher instance.
+    /// </summary>
+    public class RunningWatcherInfo {
+        public WatcherSettings Definition { get; set; }
+        public CancellationTokenSource Cancellation { get; set; }
+        public DateTime Started { get; set; }
+    }
+
+    /// <summary>
+    /// Global registry for watcher definitions and running instances.
+    /// </summary>
+    public static class WatcherRegistry {
+        private static readonly ConcurrentDictionary<string, WatcherSettings> Definitions = new();
+        private static readonly ConcurrentDictionary<string, RunningWatcherInfo> Running = new();
+
+        public static void Register(WatcherSettings def) {
+            if (string.IsNullOrEmpty(def?.Name)) {
+                throw new ArgumentException("Watcher name must be provided", nameof(def));
+            }
+            Definitions[def.Name] = def;
+        }
+
+        public static bool TryGet(string name, out WatcherSettings def) => Definitions.TryGetValue(name, out def);
+
+        public static IEnumerable<WatcherSettings> GetAllDefinitions() => Definitions.Values;
+
+        public static bool RemoveDefinition(string name) => Definitions.TryRemove(name, out _);
+
+        public static IReadOnlyDictionary<string, RunningWatcherInfo> GetRunning() => Running;
+
+        public static bool Stop(string name) {
+            if (Running.TryRemove(name, out var info)) {
+                info.Cancellation.Cancel();
+                return true;
+            }
+            return false;
+        }
+
+        public static string Start(string name, InternalLogger logger, WatcherSettings def, int timeoutSeconds, bool stopOnMatch, int stopAfter, ScriptBlock until, CancellationToken token) {
+            var cts = CancellationTokenSource.CreateLinkedTokenSource(token);
+            if (timeoutSeconds > 0) {
+                cts.CancelAfter(TimeSpan.FromSeconds(timeoutSeconds));
+            }
+
+            int matches = 0;
+            var watcher = new WatchEvents(logger) {
+                NumberOfThreads = def.NumberOfThreads
+            };
+
+            watcher.Watch(def.MachineName, def.LogName, def.EventId.ToList(), e => {
+                def.Action.Invoke(e);
+                bool stop = false;
+                if (until != null) {
+                    object result = until.InvokeReturnAsIs(e);
+                    if (LanguagePrimitives.IsTrue(result)) {
+                        stop = true;
+                    }
+                }
+                if (stopOnMatch) {
+                    stop = true;
+                }
+                if (stopAfter > 0 && Interlocked.Increment(ref matches) >= stopAfter) {
+                    stop = true;
+                }
+                if (stop) {
+                    cts.Cancel();
+                }
+            }, cts.Token);
+
+            cts.Token.Register(() => watcher.Dispose());
+
+            var info = new RunningWatcherInfo {
+                Definition = def,
+                Cancellation = cts,
+                Started = DateTime.UtcNow
+            };
+            Running[name] = info;
+            return name;
+        }
+    }
+}

--- a/Tests/Start-EVXWatcher.Tests.ps1
+++ b/Tests/Start-EVXWatcher.Tests.ps1
@@ -5,4 +5,16 @@ Describe 'Start-EVXWatcher - Parameter validation' {
     It 'Fails when NumberOfThreads is greater than 1024' {
         { Start-EVXWatcher -MachineName $env:COMPUTERNAME -LogName 'Application' -EventId 1 -Action {} -NumberOfThreads 2000 } | Should -Throw
     }
+
+    It 'Accepts timeout parameters' {
+        { Start-EVXWatcher -MachineName $env:COMPUTERNAME -LogName 'Application' -EventId 1 -Action {} -TimeoutSeconds 1 -StopOnMatch } | Should -Not -Throw
+    }
+
+    It 'Registers and starts watcher by name' {
+        Register-EVXWatcher -Name 'TestWatcher' -MachineName $env:COMPUTERNAME -LogName 'Application' -EventId 1 -Action {}
+        $id = Start-EVXWatcher -Name 'TestWatcher'
+        ($id | Should -Not -BeNullOrEmpty)
+        Get-EVXWatcher -Running | Where-Object { $_.Name -eq $id } | Should -Not -BeNullOrEmpty
+        Remove-EVXWatcher -Name $id | Should -Be $true
+    }
 }


### PR DESCRIPTION
## Summary
- add WatcherRegistry to keep registered and running watchers
- implement Register-EVXWatcher, Get-EVXWatcher and Remove-EVXWatcher
- extend Start-EVXWatcher to run watchers by name and return watcher id
- document watcher management in README
- include simple Pester check for watcher registration

## Testing
- `dotnet build Sources/EventViewerX.sln -c Release`
- `pwsh -NoLogo -File ./PSEventViewer.Tests.ps1` *(failed: Write-Color/Invoke-Pester missing)*

------
https://chatgpt.com/codex/tasks/task_e_686595f3be28832e841e92ddc7429e4e