### PR TITLE
Add watcher manager to library and provide examples

### DIFF
--- a/Examples/Example.WatchBasic.ps1
+++ b/Examples/Example.WatchBasic.ps1
@@ -1,0 +1,15 @@
+Import-Module $PSScriptRoot/../PSEventViewer.psd1 -Force
+
+$action = {
+    param($Event)
+    Write-Host "Found event $($Event.Id) on $($Event.Computer)"
+}
+
+$watcher = Start-EVXWatcher -Name 'BasicWatcher' -MachineName $env:COMPUTERNAME -LogName 'Security' -EventId 4624,4625 -Action $action
+
+# Wait for events to arrive
+Start-Sleep -Seconds 30
+
+Get-EVXWatcher -Id $watcher.Id | Format-List
+
+Stop-EVXWatcher -Id $watcher.Id

--- a/Examples/Example.WatchNamedEvents.ps1
+++ b/Examples/Example.WatchNamedEvents.ps1
@@ -1,0 +1,14 @@
+Import-Module $PSScriptRoot/../PSEventViewer.psd1 -Force
+
+$action = {
+    param($Event)
+    Write-Host "Named event $($Event.Type) detected"
+}
+
+$watcher = Start-EVXWatcher -Name 'NamedWatcher' -MachineName $env:COMPUTERNAME -LogName 'System' -NamedEvent OSCrash,OSBugCheck -Action $action
+
+Start-Sleep -Seconds 30
+
+Get-EVXWatcher -Name 'NamedWatcher'
+
+Stop-EVXWatcher -Name 'NamedWatcher'

--- a/Examples/Example.WatchStopAfter.ps1
+++ b/Examples/Example.WatchStopAfter.ps1
@@ -1,0 +1,13 @@
+Import-Module $PSScriptRoot/../PSEventViewer.psd1 -Force
+
+$action = {
+    param($Event)
+    Write-Host "Event $($Event.Id) captured"
+}
+
+Start-EVXWatcher -Name 'StopAfterWatcher' -MachineName $env:COMPUTERNAME -LogName 'Security' -EventId 4625 -Action $action -StopAfter 2
+
+# Wait for watcher to stop itself after two events
+Start-Sleep -Seconds 60
+
+Get-EVXWatcher

--- a/Examples/Example.WatchTimeout.ps1
+++ b/Examples/Example.WatchTimeout.ps1
@@ -1,0 +1,12 @@
+Import-Module $PSScriptRoot/../PSEventViewer.psd1 -Force
+
+$action = {
+    param($Event)
+    Write-Host "Timeout watcher saw $($Event.Id)"
+}
+
+Start-EVXWatcher -Name 'TimeoutWatcher' -MachineName $env:COMPUTERNAME -LogName 'Application' -EventId 1000 -Action $action -TimeOut (New-TimeSpan -Seconds 30)
+
+Start-Sleep -Seconds 40
+
+Get-EVXWatcher

--- a/PSEventViewer.psd1
+++ b/PSEventViewer.psd1
@@ -1,7 +1,7 @@
 ﻿@{
-    AliasesToExport      = @('Get-EventViewerXEvent', 'Find-WinEvent', 'Get-Events', 'Get-EventViewerXFilter', 'Get-WinEventFilter', 'Get-EventsFilter', 'Get-EventViewerXInfo', 'Get-EventsSettings', 'Get-EventsInformation', 'Restore-EVXPowerShellScript', 'Get-PowerShellScriptExecution', 'Restore-PowerShellScript', 'Get-EventViewerXProviderList', 'Remove-EventViewerXSource', 'Remove-WinEventSource', 'Set-EventViewerXInfo', 'Set-EventsInformation', 'Set-EventsSettings', 'Start-EventViewerXWatcher', 'Start-EventWatching', 'Write-EventViewerXEntry', 'Write-WinEvent')
+    AliasesToExport      = @('Get-EventViewerXEvent', 'Find-WinEvent', 'Get-Events', 'Get-EventViewerXFilter', 'Get-WinEventFilter', 'Get-EventsFilter', 'Get-EventViewerXInfo', 'Get-EventsSettings', 'Get-EventsInformation', 'Restore-EVXPowerShellScript', 'Get-PowerShellScriptExecution', 'Restore-PowerShellScript', 'Get-EventViewerXProviderList', 'Remove-EventViewerXSource', 'Remove-WinEventSource', 'Set-EventViewerXInfo', 'Set-EventsInformation', 'Set-EventsSettings', 'Start-EventViewerXWatcher', 'Start-EventWatching', 'Stop-EventViewerXWatcher', 'Get-EventViewerXWatcher', 'Write-EventViewerXEntry', 'Write-WinEvent')
     Author               = 'Przemyslaw Klys'
-    CmdletsToExport      = @('Get-EVXEvent', 'Get-EVXFilter', 'Get-EVXInfo', 'Get-EVXPowerShellScript', 'Get-EVXProviderList', 'Remove-EVXSource', 'Set-EVXInfo', 'Start-EVXWatcher', 'Write-EVXEntry')
+    CmdletsToExport      = @('Get-EVXEvent', 'Get-EVXFilter', 'Get-EVXInfo', 'Get-EVXPowerShellScript', 'Get-EVXProviderList', 'Remove-EVXSource', 'Set-EVXInfo', 'Start-EVXWatcher', 'Stop-EVXWatcher', 'Get-EVXWatcher', 'Write-EVXEntry')
     CompanyName          = 'Evotec'
     CompatiblePSEditions = @('Desktop', 'Core')
     Copyright            = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'

--- a/Sources/EventViewerX.Examples/Examples.Watchers.cs
+++ b/Sources/EventViewerX.Examples/Examples.Watchers.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
+namespace EventViewerX.Examples {
+    internal partial class Examples {
+        public static void WatchBasic() {
+            var watcher = WatcherManager.StartWatcher(
+                "basic",
+                Environment.MachineName,
+                "Security",
+                new List<int> { 4624, 4625 },
+                new List<NamedEvents>(),
+                e => Console.WriteLine($"Event {e.Id} arrived"),
+                4,
+                false,
+                false,
+                0,
+                null);
+            Thread.Sleep(TimeSpan.FromSeconds(30));
+            Console.WriteLine($"Events found: {watcher.EventsFound}");
+            WatcherManager.StopAll();
+        }
+
+        public static void WatchNamedEvents() {
+            var watcher = WatcherManager.StartWatcher(
+                "named",
+                Environment.MachineName,
+                "System",
+                EventObjectSlim.GetEventInfoForNamedEvents(new List<NamedEvents> { NamedEvents.OSCrash })["System"].ToList(),
+                new List<NamedEvents> { NamedEvents.OSCrash },
+                e => Console.WriteLine($"Named event {e.Id}"),
+                4,
+                false,
+                false,
+                0,
+                null);
+            Thread.Sleep(TimeSpan.FromSeconds(30));
+            WatcherManager.StopWatcher(watcher.Id);
+        }
+
+        public static void WatchWithStopAfter() {
+            var watcher = WatcherManager.StartWatcher(
+                "stopAfter",
+                Environment.MachineName,
+                "Security",
+                new List<int> { 4625 },
+                new List<NamedEvents>(),
+                e => Console.WriteLine("Event " + e.Id),
+                4,
+                false,
+                false,
+                2,
+                null);
+            while (WatcherManager.GetWatchers("stopAfter").Any()) {
+                Thread.Sleep(1000);
+            }
+        }
+
+        public static void WatchWithTimeout() {
+            var watcher = WatcherManager.StartWatcher(
+                "timeout",
+                Environment.MachineName,
+                "Application",
+                new List<int> { 1000 },
+                new List<NamedEvents>(),
+                e => Console.WriteLine("Event " + e.Id),
+                4,
+                false,
+                false,
+                0,
+                TimeSpan.FromSeconds(10));
+            Thread.Sleep(TimeSpan.FromSeconds(15));
+            Console.WriteLine($"Ended at {watcher.EndTime}");
+        }
+    }
+}

--- a/Sources/EventViewerX/WatchEvents.cs
+++ b/Sources/EventViewerX/WatchEvents.cs
@@ -8,6 +8,9 @@ using System.Threading;
 namespace EventViewerX {
     public class WatchEvents : Settings, IDisposable {
         public static volatile int NumberOfEventsFound = 0;
+        private int _eventsFound;
+        public int EventsFound => _eventsFound;
+        public DateTime StartTime { get; private set; }
         /// <summary>
         /// List of event IDs to watch for
         /// </summary>
@@ -46,6 +49,8 @@ namespace EventViewerX {
 
         public void Watch(string machineName, string logName, List<int> eventId, Action<EventObject> eventAction = null, CancellationToken cancellationToken = default, bool staging = false, string enabledBy = null) {
             NumberOfEventsFound = 0;
+            _eventsFound = 0;
+            StartTime = DateTime.UtcNow;
             Dispose();
             _machineName = machineName;
             if (staging && !eventId.Contains(350)) {
@@ -84,6 +89,7 @@ namespace EventViewerX {
                 var Event = Args.EventRecord;
                 if (_watchEventId.Contains(Event.Id)) {
                     Interlocked.Increment(ref NumberOfEventsFound);
+                    Interlocked.Increment(ref _eventsFound);
                     _logger.WriteVerbose("Found event id {0} on {1}.", Event.Id, Event.MachineName);
 
                     var eventObject = new EventObject(Event, _machineName);
@@ -107,6 +113,7 @@ namespace EventViewerX {
             StagingEnabledBy = null;
             _eventLogSession?.Dispose();
             _eventLogSession = null;
+            StartTime = default;
         }
     }
 }

--- a/Sources/EventViewerX/WatcherManager.cs
+++ b/Sources/EventViewerX/WatcherManager.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EventViewerX {
+    /// <summary>
+    /// Represents information about a running watcher instance.
+    /// </summary>
+    public class WatcherInfo : IDisposable {
+        internal WatcherInfo(string name, string machineName, string logName, List<int> eventIds, List<NamedEvents> namedEvents, Action<EventObject> action, int numberOfThreads, bool staging, bool stopOnMatch, int stopAfter, TimeSpan? timeout) {
+            Name = name;
+            MachineName = machineName;
+            LogName = logName;
+            EventIds = eventIds;
+            NamedEvents = namedEvents;
+            Action = action;
+            StopOnMatch = stopOnMatch;
+            StopAfter = stopAfter;
+            Timeout = timeout;
+            _staging = staging;
+            Watcher = new WatchEvents(new InternalLogger(false)) { NumberOfThreads = numberOfThreads };
+        }
+
+        private readonly bool _staging;
+        public Guid Id { get; } = Guid.NewGuid();
+        public string Name { get; }
+        public string MachineName { get; }
+        public string LogName { get; }
+        public List<int> EventIds { get; }
+        public List<NamedEvents> NamedEvents { get; }
+        public Action<EventObject> Action { get; }
+        public bool StopOnMatch { get; }
+        public int StopAfter { get; }
+        public TimeSpan? Timeout { get; }
+        internal CancellationTokenSource Cancellation { get; } = new();
+        internal Task? TimeoutTask { get; private set; }
+        public WatchEvents Watcher { get; }
+
+        public int EventsFound => Watcher.EventsFound;
+        public DateTime StartTime => Watcher.StartTime;
+        public DateTime? EndTime { get; private set; }
+
+        public void Start() {
+            Watcher.Watch(MachineName, LogName, EventIds, OnEvent, Cancellation.Token, _staging, Environment.UserName);
+            if (Timeout.HasValue) {
+                TimeoutTask = Task.Run(async () => {
+                    try {
+                        await Task.Delay(Timeout.Value, Cancellation.Token);
+                        Stop();
+                    } catch (TaskCanceledException) { }
+                });
+            }
+        }
+
+        private void OnEvent(EventObject obj) {
+            try {
+                Action?.Invoke(obj);
+            } catch {
+                // ignore user errors
+            }
+            if (StopOnMatch) {
+                Stop();
+            } else if (StopAfter > 0 && Watcher.EventsFound >= StopAfter) {
+                Stop();
+            }
+        }
+
+        public void Stop() {
+            Cancellation.Cancel();
+            Watcher.Dispose();
+            EndTime = DateTime.UtcNow;
+        }
+
+        public void Dispose() {
+            Stop();
+            Cancellation.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Manages active watcher instances.
+    /// </summary>
+    public static class WatcherManager {
+        private static readonly ConcurrentDictionary<Guid, WatcherInfo> _watchers = new();
+
+        public static WatcherInfo StartWatcher(string? name, string machineName, string logName, List<int> eventIds, List<NamedEvents> namedEvents, Action<EventObject> action, int numberOfThreads, bool staging, bool stopOnMatch, int stopAfter, TimeSpan? timeout) {
+            var info = new WatcherInfo(name ?? string.Empty, machineName, logName, eventIds, namedEvents, action, numberOfThreads, staging, stopOnMatch, stopAfter, timeout);
+            if (_watchers.TryAdd(info.Id, info)) {
+                info.Start();
+            }
+            return info;
+        }
+
+        public static IReadOnlyCollection<WatcherInfo> GetWatchers(string? name = null) {
+            if (string.IsNullOrEmpty(name)) {
+                return _watchers.Values.ToList();
+            }
+            return _watchers.Values.Where(w => string.Equals(w.Name, name, StringComparison.OrdinalIgnoreCase)).ToList();
+        }
+
+        public static bool StopWatcher(Guid id) {
+            if (_watchers.TryRemove(id, out var info)) {
+                info.Dispose();
+                return true;
+            }
+            return false;
+        }
+
+        public static void StopWatchersByName(string name) {
+            foreach (var w in GetWatchers(name)) {
+                StopWatcher(w.Id);
+            }
+        }
+
+        public static void StopAll() {
+            foreach (var id in _watchers.Keys.ToList()) {
+                StopWatcher(id);
+            }
+        }
+    }
+}

--- a/Sources/PSEventViewer/CmdletGetEVXWatcher.cs
+++ b/Sources/PSEventViewer/CmdletGetEVXWatcher.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Linq;
+using System.Management.Automation;
+using EventViewerX;
+
+namespace PSEventViewer {
+    [Cmdlet(VerbsCommon.Get, "EVXWatcher")]
+    [Alias("Get-EventViewerXWatcher")]
+    [OutputType(typeof(WatcherInfo))]
+    public sealed class CmdletGetEVXWatcher : PSCmdlet {
+        [Parameter(Position = 0, ValueFromPipelineByPropertyName = true)]
+        public Guid[] Id { get; set; }
+
+        [Parameter]
+        public string Name { get; set; }
+
+        protected override void ProcessRecord() {
+            var watchers = WatcherManager.GetWatchers(Name);
+            if (Id != null && Id.Length > 0) {
+                watchers = watchers.Where(w => Id.Contains(w.Id)).ToList();
+            }
+            foreach (var watcher in watchers) {
+                WriteObject(watcher);
+            }
+        }
+    }
+}

--- a/Sources/PSEventViewer/CmdletStopEVXWatcher.cs
+++ b/Sources/PSEventViewer/CmdletStopEVXWatcher.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Management.Automation;
+using System.Linq;
+using EventViewerX;
+
+namespace PSEventViewer {
+    [Cmdlet(VerbsLifecycle.Stop, "EVXWatcher")]
+    [Alias("Stop-EventViewerXWatcher")]
+    public sealed class CmdletStopEVXWatcher : PSCmdlet {
+        [Parameter(Position = 0, ValueFromPipelineByPropertyName = true)]
+        public Guid[] Id { get; set; }
+
+        [Parameter]
+        public string Name { get; set; }
+
+        [Parameter]
+        public SwitchParameter All { get; set; }
+
+        protected override void ProcessRecord() {
+            if (All.IsPresent) {
+                WatcherManager.StopAll();
+                return;
+            }
+
+            if (!string.IsNullOrEmpty(Name)) {
+                WatcherManager.StopWatchersByName(Name);
+            }
+
+            if (Id != null) {
+                foreach (var guid in Id) {
+                    WatcherManager.StopWatcher(guid);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- move WatcherManager into EventViewerX library for reuse
- adjust Start/Stop/Get EVXWatcher cmdlets to call new library API
- provide PowerShell watcher examples
- add C# examples demonstrating WatcherManager

## Testing
- `dotnet build Sources/PSEventViewer/PSEventViewer.csproj -c Release`
- `dotnet build Sources/EventViewerX.sln -c Release`
- `dotnet test Sources/EventViewerX.sln`
- `pwsh -NoLogo -NoProfile -Command ./PSEventViewer.Tests.ps1` *(fails: Write-Color not found)*

------
https://chatgpt.com/codex/tasks/task_e_686784a7fff4832e8dde530a1f15852c