### PR TITLE
Fix remaining event rule base classes

### DIFF
--- a/Sources/EventViewerX/Enums/NamedEvents.cs
+++ b/Sources/EventViewerX/Enums/NamedEvents.cs
@@ -59,6 +59,11 @@
         ADGroupPolicyLinks,
 
         /// <summary>
+        /// Detailed audit information for group policy changes
+        /// </summary>
+        ADGroupPolicyChangesDetailed,
+
+        /// <summary>
         /// Group Policy Object created
         /// </summary>
         GpoCreated,

--- a/Sources/EventViewerX/Rules/ActiveDirectory/GroupPolicies/ADGroupPolicyChangesDetailed.cs
+++ b/Sources/EventViewerX/Rules/ActiveDirectory/GroupPolicies/ADGroupPolicyChangesDetailed.cs
@@ -1,9 +1,9 @@
-﻿namespace EventViewerX.Rules.ActiveDirectory;
+namespace EventViewerX.Rules.ActiveDirectory;
 
 /// <summary>
 /// Detailed audit information for group policy changes.
 /// </summary>
-public class ADGroupPolicyChangesDetailed : EventObjectSlim {
+public class ADGroupPolicyChangesDetailed : EventRuleBase {
     public string Computer;
     public string Action;
     public string ObjectClass;
@@ -13,6 +13,14 @@ public class ADGroupPolicyChangesDetailed : EventObjectSlim {
     public string GpoName;
     public string AttributeLDAPDisplayName;
     public string AttributeValue;
+    public override List<int> EventIds => new() { 5136, 5137, 5139, 5141 };
+    public override string LogName => "Security";
+    public override NamedEvents NamedEvent => NamedEvents.ADGroupPolicyChangesDetailed;
+
+    public override bool CanHandle(EventObject eventObject) {
+        return eventObject.Data.TryGetValue("ObjectClass", out var objectClass) &&
+               objectClass == "groupPolicyContainer";
+    }
 
     public ADGroupPolicyChangesDetailed(EventObject eventObject) : base(eventObject) {
         _eventObject = eventObject;

--- a/Sources/EventViewerX/Rules/ActiveDirectory/SMB/SMBServerAudit.cs
+++ b/Sources/EventViewerX/Rules/ActiveDirectory/SMB/SMBServerAudit.cs
@@ -14,14 +14,21 @@ namespace EventViewerX.Rules.ActiveDirectory;
 /// HKLM\SYSTEM\CurrentControlSet\Services\LanmanServer\Parameters
 /// AuditSmb1Access => REG_DWORD => 1
 /// </summary>
-[EventRule(NamedEvents.ADSMBServerAuditV1, "Microsoft-Windows-SMBServer/Audit", 3000)]
-public class SMBServerAudit : EventObjectSlim {
+public class SMBServerAudit : EventRuleBase {
     // public EventObject EventObject { get; }
     public string Computer;
     public string Action;
     public string ClientAddress;
     public string ClientDNSName = string.Empty;
     public DateTime When;
+    public override List<int> EventIds => new() { 3000 };
+    public override string LogName => "Microsoft-Windows-SMBServer/Audit";
+    public override NamedEvents NamedEvent => NamedEvents.ADSMBServerAuditV1;
+
+    public override bool CanHandle(EventObject eventObject) {
+        // Simple rule - always handle if event ID and log name match
+        return true;
+    }
 
     // public ctor that performs partial initialization
     public SMBServerAudit(EventObject eventObject) : base(eventObject) {

--- a/Sources/EventViewerX/Rules/CertificateAuthority/CertificateIssued.cs
+++ b/Sources/EventViewerX/Rules/CertificateAuthority/CertificateIssued.cs
@@ -1,12 +1,21 @@
-﻿namespace EventViewerX.Rules.CertificateAuthority;
+namespace EventViewerX.Rules.CertificateAuthority;
 
 /// <summary>
 /// Certificate issued by Certificate Authority
 /// 4886: Certificate Services received a certificate request
 /// 4887: Certificate Services approved a certificate request and issued a certificate
 /// </summary>
-public class CertificateIssued : EventObjectSlim
+public class CertificateIssued : EventRuleBase
 {
+    public override List<int> EventIds => new() { 4886, 4887 };
+    public override string LogName => "Security";
+    public override NamedEvents NamedEvent => NamedEvents.CertificateIssued;
+
+    public override bool CanHandle(EventObject eventObject)
+    {
+        // Simple rule - always handle if event ID and log name match
+        return true;
+    }
     public string Computer;
     public string Action;
     public string CertificateTemplate;

--- a/Sources/EventViewerX/Rules/Kerberos/KerberosPolicyChange.cs
+++ b/Sources/EventViewerX/Rules/Kerberos/KerberosPolicyChange.cs
@@ -1,10 +1,19 @@
-﻿namespace EventViewerX.Rules.Kerberos;
+namespace EventViewerX.Rules.Kerberos;
 
 /// <summary>
 /// Kerberos policy configuration change event details.
 /// </summary>
-public class KerberosPolicyChange : EventObjectSlim
+public class KerberosPolicyChange : EventRuleBase
 {
+    public override List<int> EventIds => new() { 4713 };
+    public override string LogName => "Security";
+    public override NamedEvents NamedEvent => NamedEvents.KerberosPolicyChange;
+
+    public override bool CanHandle(EventObject eventObject)
+    {
+        // Simple rule - always handle if event ID and log name match
+        return true;
+    }
     public string Computer;
     public string Who;
     public string PolicyChanges;

--- a/Sources/EventViewerX/Rules/Kerberos/KerberosServiceTicket.cs
+++ b/Sources/EventViewerX/Rules/Kerberos/KerberosServiceTicket.cs
@@ -1,10 +1,19 @@
-﻿namespace EventViewerX.Rules.Kerberos;
+namespace EventViewerX.Rules.Kerberos;
 
 /// <summary>
 /// Represents a Kerberos service ticket request event.
 /// </summary>
-public class KerberosServiceTicket : EventObjectSlim
+public class KerberosServiceTicket : EventRuleBase
 {
+    public override List<int> EventIds => new() { 4769, 4770 };
+    public override string LogName => "Security";
+    public override NamedEvents NamedEvent => NamedEvents.KerberosServiceTicket;
+
+    public override bool CanHandle(EventObject eventObject)
+    {
+        // Simple rule - always handle if event ID and log name match
+        return true;
+    }
     public string Computer;
     public string Action;
     public string AccountName;

--- a/Sources/EventViewerX/Rules/Kerberos/KerberosTGTRequest.cs
+++ b/Sources/EventViewerX/Rules/Kerberos/KerberosTGTRequest.cs
@@ -1,10 +1,19 @@
-﻿namespace EventViewerX.Rules.Kerberos;
+namespace EventViewerX.Rules.Kerberos;
 
 /// <summary>
 /// Represents a Kerberos TGT request event.
 /// </summary>
-public class KerberosTGTRequest : EventObjectSlim
+public class KerberosTGTRequest : EventRuleBase
 {
+    public override List<int> EventIds => new() { 4768 };
+    public override string LogName => "Security";
+    public override NamedEvents NamedEvent => NamedEvents.KerberosTGTRequest;
+
+    public override bool CanHandle(EventObject eventObject)
+    {
+        // Simple rule - always handle if event ID and log name match
+        return true;
+    }
     public string Computer;
     public string Action;
     public string AccountName;

--- a/Sources/EventViewerX/Rules/Kerberos/KerberosTicketFailure.cs
+++ b/Sources/EventViewerX/Rules/Kerberos/KerberosTicketFailure.cs
@@ -1,10 +1,19 @@
-﻿namespace EventViewerX.Rules.Kerberos;
+namespace EventViewerX.Rules.Kerberos;
 
 /// <summary>
 /// Represents a failed Kerberos ticket request event.
 /// </summary>
-public class KerberosTicketFailure : EventObjectSlim
+public class KerberosTicketFailure : EventRuleBase
 {
+    public override List<int> EventIds => new() { 4771, 4772 };
+    public override string LogName => "Security";
+    public override NamedEvents NamedEvent => NamedEvents.KerberosTicketFailure;
+
+    public override bool CanHandle(EventObject eventObject)
+    {
+        // Simple rule - always handle if event ID and log name match
+        return true;
+    }
     public string Computer;
     public string Action;
     public string AccountName;

--- a/Sources/EventViewerX/Rules/Windows/ClientGroupPolicies.cs
+++ b/Sources/EventViewerX/Rules/Windows/ClientGroupPolicies.cs
@@ -1,9 +1,9 @@
 namespace EventViewerX.Rules.Windows;
 
 /// <summary>
-/// Represents client side group policy processing details.
+/// Base class for client side group policy processing events.
 /// </summary>
-public class ClientGroupPolicies : EventObjectSlim {
+public abstract class ClientGroupPoliciesBase : EventRuleBase {
     public string Computer;
     public string Action;
     public string PolicyScope;
@@ -13,9 +13,9 @@ public class ClientGroupPolicies : EventObjectSlim {
     public string Who;
     public DateTime When;
 
-    public ClientGroupPolicies(EventObject eventObject) : base(eventObject) {
+    protected ClientGroupPoliciesBase(EventObject eventObject) : base(eventObject) {
         _eventObject = eventObject;
-        Type = "ClientGroupPolicies";
+        Type = GetType().Name;
         Computer = _eventObject.ComputerName;
         Action = _eventObject.MessageSubject;
         PolicyScope = _eventObject.GetValueFromDataDictionary("NoNameA0");
@@ -25,4 +25,31 @@ public class ClientGroupPolicies : EventObjectSlim {
         Who = _eventObject.GetValueFromDataDictionary("SubjectUserName", "SubjectDomainName", "\\", reverseOrder: true);
         When = _eventObject.TimeCreated;
     }
+
+    public override bool CanHandle(EventObject eventObject) {
+        // Simple rule - always handle if event ID and log name match
+        return true;
+    }
+}
+
+/// <summary>
+/// Client side group policy processing events from the Application log.
+/// </summary>
+public class ClientGroupPoliciesApplication : ClientGroupPoliciesBase {
+    public override List<int> EventIds => new() { 4098 };
+    public override string LogName => "Application";
+    public override NamedEvents NamedEvent => NamedEvents.ClientGroupPoliciesApplication;
+
+    public ClientGroupPoliciesApplication(EventObject eventObject) : base(eventObject) { }
+}
+
+/// <summary>
+/// Client side group policy processing events from the System log.
+/// </summary>
+public class ClientGroupPoliciesSystem : ClientGroupPoliciesBase {
+    public override List<int> EventIds => new() { 1085 };
+    public override string LogName => "System";
+    public override NamedEvents NamedEvent => NamedEvents.ClientGroupPoliciesSystem;
+
+    public ClientGroupPoliciesSystem(EventObject eventObject) : base(eventObject) { }
 }


### PR DESCRIPTION
## Summary
- convert SMBServerAudit to inherit from `EventRuleBase`
- convert `ADGroupPolicyChangesDetailed` rule and add enum entry
- split client Group Policy rule into `ClientGroupPoliciesApplication` and `ClientGroupPoliciesSystem`

## Testing
- `dotnet build Sources/EventViewerX/EventViewerX.csproj -c Release` *(fails: .NET 9.0 SDK not installed)*
- `pwsh -NoLogo -NoProfile -Command ./PSEventViewer.Tests.ps1` *(fails: Write-Color module missing)*

------
https://chatgpt.com/codex/tasks/task_e_68684c286644832ebdc608ff50c2428b