### PR TITLE
Add Codecov integration

### DIFF
--- a/.github/workflows/test-dotnet.yml
+++ b/.github/workflows/test-dotnet.yml
@@ -53,3 +53,9 @@ jobs:
         with:
           name: coverage-reports-windows-${{ matrix.dotnet-version }}
           path: '**/coverage.cobertura.xml'
+
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: '**/coverage.cobertura.xml'
+          verbose: true

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
   <a href="https://www.powershellgallery.com/packages/PSEventViewer"><img src="https://img.shields.io/powershellgallery/v/PSEventViewer.svg"></a>
   <a href="https://www.powershellgallery.com/packages/PSEventViewer"><img src="https://img.shields.io/powershellgallery/vpre/PSEventViewer.svg?label=powershell%20gallery%20preview&colorB=yellow"></a>
   <a href="https://github.com/EvotecIT/PSEventViewer"><img src="https://img.shields.io/github/license/EvotecIT/PSEventViewer.svg"></a>
+  <a href="https://codecov.io/gh/EvotecIT/PSEventViewer"><img src="https://codecov.io/gh/EvotecIT/PSEventViewer/branch/master/graph/badge.svg"></a>
 </p>
 
 <p align="center">

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+codecov:
+  require_ci_to_pass: false
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+    patch:
+      default:
+        target: auto


### PR DESCRIPTION
## Summary
- add Codecov upload step to CI
- show Codecov badge in README
- add default `codecov.yml`

## Testing
- `dotnet build Sources/EventViewerX.sln -c Debug`
- `dotnet test Sources/EventViewerX.sln --no-build -c Debug`
- `pwsh ./PSEventViewer.Tests.ps1` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_6868f74252d4832eaf73d1bffce14af1