### PR TITLE
Add XML documentation for public members

### DIFF
--- a/Sources/EventViewerX/EventObject.cs
+++ b/Sources/EventViewerX/EventObject.cs
@@ -38,46 +38,103 @@ namespace EventViewerX {
         /// </summary>
         public string ComputerName => _eventRecord.MachineName;
 
+        /// <summary>
+        /// Human readable event level name.
+        /// </summary>
         public string LevelDisplayName => _eventRecord.LevelDisplayName;
 
+        /// <summary>
+        /// Provider that generated the event.
+        /// </summary>
         public string ProviderName => _eventRecord.ProviderName;
 
+        /// <summary>
+        /// Additional event qualifiers if present.
+        /// </summary>
         public string Qualifiers => _eventRecord.Qualifiers?.ToString();
 
+        /// <summary>
+        /// Opcode of the event record.
+        /// </summary>
         public short? Opcode => _eventRecord.Opcode;
 
+        /// <summary>
+        /// Identifier of the event provider.
+        /// </summary>
         public Guid? ProviderId => _eventRecord.ProviderId;
 
+        /// <summary>
+        /// Related activity identifier if any.
+        /// </summary>
         public Guid? RelatedActivityId => _eventRecord.RelatedActivityId;
 
+        /// <summary>
+        /// Activity identifier for correlation.
+        /// </summary>
         public Guid? ActivityId => _eventRecord.ActivityId;
 
+        /// <summary>
+        /// Security identifier associated with the event.
+        /// </summary>
         public SecurityIdentifier UserId => _eventRecord.UserId;
 
+        /// <summary>
+        /// Event bookmark for resuming queries.
+        /// </summary>
         public EventBookmark Bookmark => _eventRecord.Bookmark;
 
+        /// <summary>
+        /// Formatted event message.
+        /// </summary>
         public string Message => _eventRecord.FormatDescription() ?? string.Empty;
 
+        /// <summary>
+        /// Display name of the task.
+        /// </summary>
         public string TaskDisplayName => _eventRecord.TaskDisplayName;
 
+        /// <summary>
+        /// Display name of the opcode.
+        /// </summary>
         public string OpcodeDisplayName => _eventRecord.OpcodeDisplayName;
 
+        /// <summary>
+        /// Keyword display names associated with the event.
+        /// </summary>
         public IEnumerable<string> KeywordsDisplayNames => _eventRecord.KeywordsDisplayNames;
 
+        /// <summary>
+        /// Keyword flags associated with the event.
+        /// </summary>
         public long? Keywords => _eventRecord.Keywords;
 
+        /// <summary>
+        /// Numeric level of the event.
+        /// </summary>
         public byte? Level => _eventRecord.Level;
 
         //public Level? Level => (Level?)_eventRecord.Level;
 
         //public Keywords? Keywords => (Keywords?)_eventRecord.Keywords;
 
+        /// <summary>
+        /// Version of the event record.
+        /// </summary>
         public byte? Version => _eventRecord.Version;
 
+        /// <summary>
+        /// Task identifier if available.
+        /// </summary>
         public int? Task => _eventRecord.Task;
 
+        /// <summary>
+        /// Identifier of the process that logged the event.
+        /// </summary>
         public int? ProcessId => _eventRecord.ProcessId;
 
+        /// <summary>
+        /// Identifier of the thread that logged the event.
+        /// </summary>
         public int? ThreadId => _eventRecord.ThreadId;
 
         /// <summary>
@@ -106,6 +163,9 @@ namespace EventViewerX {
         /// </summary>
         public Dictionary<string, string> MessageData { get; private set; }
 
+        /// <summary>
+        /// First line of the formatted message.
+        /// </summary>
         public string MessageSubject;
 
         /// <summary>
@@ -119,17 +179,20 @@ namespace EventViewerX {
         public string XMLData;
 
         /// <summary>
-        /// Machine where the event was queried from
+        /// <summary>
+        /// Machine from which the event was queried.
         /// </summary>
         public string QueriedMachine;
 
         /// <summary>
-        /// Source where the event was gathered from (computer name or file path)
+        /// <summary>
+        /// Source from which the event was gathered (computer name or file path).
         /// </summary>
         public string GatheredFrom;
 
         /// <summary>
-        /// Log name where the event was gathered from
+        /// <summary>
+        /// Log name that contained the event.
         /// </summary>
         public string GatheredLogName;
 

--- a/Sources/EventViewerX/EventObjectSlim.cs
+++ b/Sources/EventViewerX/EventObjectSlim.cs
@@ -9,11 +9,34 @@ using EventViewerX.Rules.NPS;
 namespace EventViewerX;
 
 public class EventObjectSlim {
+    /// <summary>
+    /// Reference to the detailed event object.
+    /// </summary>
     public EventObject _eventObject;
+
+    /// <summary>
+    /// Identifier of the event.
+    /// </summary>
     public int EventID; // = _eventObject.Id;
+
+    /// <summary>
+    /// Record identifier of the event.
+    /// </summary>
     public long? RecordID; // = _eventObject.RecordId;
+
+    /// <summary>
+    /// Source machine from which the event was gathered.
+    /// </summary>
     public string GatheredFrom; // = _eventObject.MachineName;
+
+    /// <summary>
+    /// Log name where the event originated.
+    /// </summary>
     public string GatheredLogName; // = _eventObject.LogName;
+
+    /// <summary>
+    /// Name of the rule type handling the event.
+    /// </summary>
     public string Type;
 
     private static readonly Dictionary<NamedEvents, Type> _eventRuleTypes = new();

--- a/Sources/EventViewerX/Rules/ActiveDirectory/Users/ADUserChangeDetailed.cs
+++ b/Sources/EventViewerX/Rules/ActiveDirectory/Users/ADUserChangeDetailed.cs
@@ -8,14 +8,49 @@
 /// 5141: A directory service object was moved
 /// </summary>
 public class ADUserChangeDetailed : EventRuleBase {
+    /// <summary>
+    /// Computer where the change occurred.
+    /// </summary>
     public string Computer;
+
+    /// <summary>
+    /// Description of the action.
+    /// </summary>
     public string Action;
+
+    /// <summary>
+    /// Class of the changed object.
+    /// </summary>
     public string ObjectClass;
+
+    /// <summary>
+    /// Operation type description.
+    /// </summary>
     public string OperationType;
+
+    /// <summary>
+    /// User performing the change.
+    /// </summary>
     public string Who;
+
+    /// <summary>
+    /// Time when the change happened.
+    /// </summary>
     public DateTime When;
+
+    /// <summary>
+    /// Affected user object.
+    /// </summary>
     public string User; // 'User Object'
+
+    /// <summary>
+    /// Name of the field that was changed.
+    /// </summary>
     public string FieldChanged; // 'Field Changed'
+
+    /// <summary>
+    /// New value of the changed field.
+    /// </summary>
     public string FieldValue; // 'Field Value'
     public override List<int> EventIds => new() { 5136, 5137, 5139, 5141 };
     public override string LogName => "Security";

--- a/Sources/EventViewerX/Rules/ActiveDirectory/Users/ADUserLogon.cs
+++ b/Sources/EventViewerX/Rules/ActiveDirectory/Users/ADUserLogon.cs
@@ -5,17 +5,64 @@
 /// 4624: An account was successfully logged on
 /// </summary>
 public class ADUserLogon : EventRuleBase {
+    /// <summary>
+    /// Computer on which the logon occurred.
+    /// </summary>
     public string Computer;
+
+    /// <summary>
+    /// Description of the logon action.
+    /// </summary>
     public string Action;
+
+    /// <summary>
+    /// IP address of the source.
+    /// </summary>
     public string IpAddress;
+
+    /// <summary>
+    /// Source port number.
+    /// </summary>
     public string IpPort;
+
+    /// <summary>
+    /// Account that logged on.
+    /// </summary>
     public string ObjectAffected;
+
+    /// <summary>
+    /// User initiating the logon.
+    /// </summary>
     public string Who;
+
+    /// <summary>
+    /// Time when the logon happened.
+    /// </summary>
     public DateTime When;
+
+    /// <summary>
+    /// Name of the logon process.
+    /// </summary>
     public string LogonProcessName;
+
+    /// <summary>
+    /// Impersonation level used.
+    /// </summary>
     public ImpersonationLevel? ImpersonationLevel;
+
+    /// <summary>
+    /// Indicates if a virtual account was used.
+    /// </summary>
     public VirtualAccount? VirtualAccount;
+
+    /// <summary>
+    /// Indicates if an elevated token was used.
+    /// </summary>
     public ElevatedToken? ElevatedToken;
+
+    /// <summary>
+    /// Logon type value.
+    /// </summary>
     public LogonType? LogonType;
 
     public override List<int> EventIds => new() { 4624 };

--- a/Sources/EventViewerX/Rules/ActiveDirectory/Users/ADUserLogonFailed.cs
+++ b/Sources/EventViewerX/Rules/ActiveDirectory/Users/ADUserLogonFailed.cs
@@ -33,24 +33,94 @@ public class ADUserLogonFailed : EventRuleBase {
         // Simple rule - always handle if event ID and log name match
         return true;
     }
+    /// <summary>
+    /// Computer on which the failed logon occurred.
+    /// </summary>
     public string Computer;
+
+    /// <summary>
+    /// Description of the failure.
+    /// </summary>
     public string Action;
+
+    /// <summary>
+    /// Authentication package name.
+    /// </summary>
     public string PackageName;
+
+    /// <summary>
+    /// IP address of the source.
+    /// </summary>
     public string IpAddress;
+
+    /// <summary>
+    /// Source port number.
+    /// </summary>
     public string IpPort;
     //public string WorkstationName;
+    /// <summary>
+    /// Account that attempted the logon.
+    /// </summary>
     public string ObjectAffected;
+
+    /// <summary>
+    /// Machine initiating the logon attempt.
+    /// </summary>
     public string Who;
+
+    /// <summary>
+    /// Time when the logon failed.
+    /// </summary>
     public DateTime When;
+
+    /// <summary>
+    /// Logon process name.
+    /// </summary>
     public string LogonProcessName;
+
+    /// <summary>
+    /// Logon type value.
+    /// </summary>
     public LogonType? LogonType;
+
+    /// <summary>
+    /// Status code returned by authentication.
+    /// </summary>
     public StatusCode? Status { get; private set; }
+
+    /// <summary>
+    /// Sub status code for the failure.
+    /// </summary>
     public SubStatusCode? SubStatus { get; private set; }
+
+    /// <summary>
+    /// Reason of the failure if available.
+    /// </summary>
     public FailureReason? FailureReason { get; private set; }
+
+    /// <summary>
+    /// LM package name used.
+    /// </summary>
     public string LmPackageName;
+
+    /// <summary>
+    /// Length of the key.
+    /// </summary>
     public string KeyLength;
+
+    /// <summary>
+    /// Process identifier of the caller.
+    /// </summary>
     public string ProcessId;
+
+    /// <summary>
+    /// Name of the process.
+    /// </summary>
     public string ProcessName;
+
+    /// <summary>
+    /// Services requested during authentication.
+    /// </summary>
     public string TransmittedServices;
 
 

--- a/Sources/EventViewerX/Rules/ActiveDirectory/Users/ADUserPrivilegeUse.cs
+++ b/Sources/EventViewerX/Rules/ActiveDirectory/Users/ADUserPrivilegeUse.cs
@@ -13,11 +13,34 @@ public class ADUserPrivilegeUse : EventRuleBase {
         // Simple rule - always handle if event ID and log name match
         return true;
     }
+    /// <summary>
+    /// Computer where the privileges were assigned.
+    /// </summary>
     public string Computer;
+
+    /// <summary>
+    /// Description of the event action.
+    /// </summary>
     public string Action;
+
+    /// <summary>
+    /// Account receiving the privileges.
+    /// </summary>
     public string Who;
+
+    /// <summary>
+    /// Time when privileges were granted.
+    /// </summary>
     public DateTime When;
+
+    /// <summary>
+    /// List of privilege names.
+    /// </summary>
     public List<string> Privileges;
+
+    /// <summary>
+    /// Translated privilege descriptions.
+    /// </summary>
     public List<string> PrivilegesTranslated;
 
     public ADUserPrivilegeUse(EventObject eventObject) : base(eventObject) {

--- a/Sources/EventViewerX/Rules/ActiveDirectory/Users/ADUserStatus.cs
+++ b/Sources/EventViewerX/Rules/ActiveDirectory/Users/ADUserStatus.cs
@@ -19,10 +19,29 @@ public class ADUserStatus : EventRuleBase {
         return true;
     }
 
+    /// <summary>
+    /// Computer where the status change occurred.
+    /// </summary>
     public string Computer;
+
+    /// <summary>
+    /// Short description of the action.
+    /// </summary>
     public string Action;
+
+    /// <summary>
+    /// User performing the change.
+    /// </summary>
     public string Who;
+
+    /// <summary>
+    /// Time of the status change.
+    /// </summary>
     public DateTime When;
+
+    /// <summary>
+    /// Account affected by the action.
+    /// </summary>
     public string UserAffected;
 
     public ADUserStatus(EventObject eventObject) : base(eventObject) {

--- a/Sources/EventViewerX/Rules/DHCP/DhcpLeaseCreated.cs
+++ b/Sources/EventViewerX/Rules/DHCP/DhcpLeaseCreated.cs
@@ -14,9 +14,24 @@ public class DhcpLeaseCreated : EventRuleBase {
         return true;
     }
 
+    /// <summary>
+    /// Computer that issued the lease.
+    /// </summary>
     public string Computer;
+
+    /// <summary>
+    /// IP address leased to the client.
+    /// </summary>
     public string IPAddress;
+
+    /// <summary>
+    /// MAC address of the client.
+    /// </summary>
     public string MacAddress;
+
+    /// <summary>
+    /// Time when the lease was created.
+    /// </summary>
     public DateTime When;
 
     public DhcpLeaseCreated(EventObject eventObject) : base(eventObject) {

--- a/Sources/EventViewerX/Rules/NPS/NetworkAccessAuthenticationPolicy.cs
+++ b/Sources/EventViewerX/Rules/NPS/NetworkAccessAuthenticationPolicy.cs
@@ -14,34 +14,124 @@ public class NetworkAccessAuthenticationPolicy : EventRuleBase {
         // Simple rule - always handle if event ID and log name match
         return true;
     }
+    /// <summary>
+    /// Computer where the policy event originated.
+    /// </summary>
     public string Computer;
+
+    /// <summary>
+    /// Brief description of the action.
+    /// </summary>
     public string Action;
+
+    /// <summary>
+    /// Security identifier of the user.
+    /// </summary>
     public string SecurityID;
+
+    /// <summary>
+    /// Account name of the user.
+    /// </summary>
     public string AccountName;
+
+    /// <summary>
+    /// Domain of the user account.
+    /// </summary>
     public string AccountDomain;
+
+    /// <summary>
+    /// Called station identifier.
+    /// </summary>
     public string CalledStationID;
+
+    /// <summary>
+    /// Calling station identifier.
+    /// </summary>
     public string CallingStationID;
 
+    /// <summary>
+    /// IPv4 address of the NAS device.
+    /// </summary>
     public string NASIPv4Address;
+
+    /// <summary>
+    /// IPv6 address of the NAS device.
+    /// </summary>
     public string NASIPv6Address;
+
+    /// <summary>
+    /// NAS identifier string.
+    /// </summary>
     public string NASIdentifier;
+
+    /// <summary>
+    /// Type of the NAS port.
+    /// </summary>
     public string NASPortType;
+
+    /// <summary>
+    /// NAS port number.
+    /// </summary>
     public string NASPort;
 
+    /// <summary>
+    /// Friendly name of the client.
+    /// </summary>
     public string ClientFriendlyName;
+
+    /// <summary>
+    /// Client IP address in readable form.
+    /// </summary>
     public string ClientFriendlyIPAddress;
 
+    /// <summary>
+    /// Connection request policy name.
+    /// </summary>
     public string ConnectionRequestPolicyName;
+
+    /// <summary>
+    /// Network policy name applied.
+    /// </summary>
     public string NetworkPolicyName;
+
+    /// <summary>
+    /// Authentication provider used.
+    /// </summary>
     public string AuthenticationProvider;
+
+    /// <summary>
+    /// Server performing the authentication.
+    /// </summary>
     public string AuthenticationServer;
+
+    /// <summary>
+    /// Authentication type selected.
+    /// </summary>
     public string AuthenticationType;
+
+    /// <summary>
+    /// EAP type value if applicable.
+    /// </summary>
     public string EAPType;
 
+    /// <summary>
+    /// Human readable reason string.
+    /// </summary>
     public string Reason;
+
+    /// <summary>
+    /// Numeric reason code.
+    /// </summary>
     public string ReasonCode;
 
+    /// <summary>
+    /// User that triggered the policy event.
+    /// </summary>
     public string Who;
+
+    /// <summary>
+    /// Time when the policy event occurred.
+    /// </summary>
     public DateTime When;
 
     public NetworkAccessAuthenticationPolicy(EventObject eventObject) : base(eventObject) {

--- a/Sources/EventViewerX/WinEventInformation.cs
+++ b/Sources/EventViewerX/WinEventInformation.cs
@@ -7,45 +7,124 @@ namespace EventViewerX {
     /// Represents detailed information about an event log or log file.
     /// </summary>
     public class WinEventInformation {
+        /// <summary>Provider source of the log.</summary>
         public string Source { get; set; }
+
+        /// <summary>Name of the machine hosting the log.</summary>
         public string MachineName { get; set; }
+
+        /// <summary>Name of the log.</summary>
         public string LogName { get; set; }
+
+        /// <summary>Type of the log such as Operational or Administrative.</summary>
         public string LogType { get; set; }
+
+        /// <summary>Isolation level for the log.</summary>
         public EventLogIsolation LogIsolation { get; set; }
+
+        /// <summary>Indicates whether the log is enabled.</summary>
         public bool IsEnabled { get; set; }
+
+        /// <summary>True when the log has reached its maximum size.</summary>
         public bool? IsLogFull { get; set; }
+
+        /// <summary>True if the log is a classic event log.</summary>
         public bool IsClassicLog { get; set; }
+
+        /// <summary>Maximum size of the log in bytes.</summary>
         public long MaximumSizeInBytes { get; set; }
+
+        /// <summary>Path to the log file.</summary>
         public string LogFilePath { get; set; }
+
+        /// <summary>Current log mode such as Circular or Retain.</summary>
         public string LogMode { get; set; }
+
+        /// <summary>Action performed on the log.</summary>
         public string EventAction { get; set; }
+
+        /// <summary>Name of the owning provider.</summary>
         public string OwningProviderName { get; set; }
+
+        /// <summary>List of provider names for this log.</summary>
         public List<string> ProviderNames { get; set; }
+
+        /// <summary>Expanded list of provider names as a string.</summary>
         public string ProviderNamesExpanded { get; set; }
+
+        /// <summary>Provider level information.</summary>
         public string ProviderLevel { get; set; }
+
+        /// <summary>Keywords configured on the provider.</summary>
         public string ProviderKeywords { get; set; }
+
+        /// <summary>Size of provider buffer.</summary>
         public int ProviderBufferSize { get; set; }
+
+        /// <summary>Minimum number of buffers for the provider.</summary>
         public int ProviderMinimumNumberOfBuffers { get; set; }
+
+        /// <summary>Maximum number of buffers for the provider.</summary>
         public int ProviderMaximumNumberOfBuffers { get; set; }
+
+        /// <summary>Latency setting for the provider.</summary>
         public int ProviderLatency { get; set; }
+
+        /// <summary>Control GUID for the provider.</summary>
         public string ProviderControlGuid { get; set; }
+
+        /// <summary>File creation time.</summary>
         public DateTime? CreationTime { get; set; }
+
+        /// <summary>Last access time of the log.</summary>
         public DateTime? LastAccessTime { get; set; }
+
+        /// <summary>Last write time of the log.</summary>
         public DateTime? LastWriteTime { get; set; }
+
+        /// <summary>Current size of the file in bytes.</summary>
         public long? FileSize { get; set; }
+
+        /// <summary>Maximum allowed file size in bytes.</summary>
         public long? FileSizeMaximum { get; set; }
+
+        /// <summary>Current file size in megabytes.</summary>
         public double? FileSizeCurrentMB { get; set; }
+
+        /// <summary>Maximum file size in megabytes.</summary>
         public double? FileSizeMaximumMB { get; set; }
+
+        /// <summary>File size as megabytes.</summary>
         public double? FileSizeMB { get; set; }
+
+        /// <summary>Maximum size allowed in megabytes.</summary>
         public double? MaximumSizeMB { get; set; }
+
+        /// <summary>Number of records contained in the log.</summary>
         public long? RecordCount { get; set; }
+
+        /// <summary>Oldest record number in the log.</summary>
         public long? OldestRecordNumber { get; set; }
+
+        /// <summary>Security descriptor of the log.</summary>
         public string SecurityDescriptor { get; set; }
+
+        /// <summary>Owner from the security descriptor.</summary>
         public string SecurityDescriptorOwner { get; set; }
+
+        /// <summary>Group from the security descriptor.</summary>
         public string SecurityDescriptorGroup { get; set; }
+
+        /// <summary>DACL from the security descriptor.</summary>
         public string SecurityDescriptorDiscretionaryAcl { get; set; }
+
+        /// <summary>SACL from the security descriptor.</summary>
         public string SecurityDescriptorSystemAcl { get; set; }
+
+        /// <summary>Date of the newest event in the log.</summary>
         public DateTime? EventNewest { get; set; }
+
+        /// <summary>Date of the oldest event in the log.</summary>
         public DateTime? EventOldest { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- add missing docs in `EventObject`
- document fields in `EventObjectSlim`
- document properties in `WinEventInformation`
- add documentation to rule classes
- tidy DHCP rule documentation

## Testing
- `dotnet restore Sources/EventViewerX.sln` *(fails: NETSDK1045)*
- `dotnet build Sources/EventViewerX.sln --no-restore -c Release` *(fails: NETSDK1045)*
- `pwsh -NoLogo -NoProfile -Command "./PSEventViewer.Tests.ps1"` *(fails: Invoke-Pester not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b66422fd4832e8b6fe849101213e7