### PR TITLE
Fix missing XML docs

### DIFF
--- a/Sources/EventViewerX/BinaryWrappers.cs
+++ b/Sources/EventViewerX/BinaryWrappers.cs
@@ -4,8 +4,15 @@ using System.IO;
 using System.Linq;
 
 namespace EventViewerX {
+    /// <summary>
+    /// Helper methods that wrap <c>wevtutil.exe</c> and related utilities.
+    /// </summary>
     public class BinaryWrappers {
 
+        /// <summary>
+        /// Imports a compiled manifest file using <c>wevtutil.exe</c>.
+        /// </summary>
+        /// <param name="manifestPath">Path to the manifest file.</param>
         public static void ImportManifest(string manifestPath) {
 
             //string manifestPath = @"C:\path\to\your\manifest.man";
@@ -41,6 +48,12 @@ namespace EventViewerX {
         }
 
 
+        /// <summary>
+        /// Compiles a manifest XML file into a <c>.man</c> file using <c>mc.exe</c>.
+        /// </summary>
+        /// <param name="xmlPath">Path to the manifest XML.</param>
+        /// <param name="manPath">Path to the output <c>.man</c> file.</param>
+        /// <param name="mcPath">Optional explicit path to <c>mc.exe</c>.</param>
         public static void ConvertXMLtoMAN(string xmlPath, string manPath, string mcPath = null) {
             //string xmlPath = @"C:\path\to\your\manifest.xml";
             //string manPath = @"C:\path\to\output\manifest.man";
@@ -91,6 +104,9 @@ namespace EventViewerX {
         }
 
 
+        /// <summary>
+        /// Displays provider names, GUIDs and associated log names.
+        /// </summary>
         public static void GetProvidersResults() {
             // Get the list of providers
             string[] providers = GetProviders();
@@ -105,14 +121,29 @@ namespace EventViewerX {
             }
         }
 
+        /// <summary>
+        /// Retrieves all registered event providers.
+        /// </summary>
+        /// <returns>Array of provider names.</returns>
         private static string[] GetProviders() {
             return RunCommand("wevtutil.exe", "ep").Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
         }
 
+        /// <summary>
+        /// Gets provider metadata text using <c>wevtutil.exe</c>.
+        /// </summary>
+        /// <param name="provider">Provider name.</param>
+        /// <returns>Metadata text.</returns>
         private static string GetProviderMetadata(string provider) {
             return RunCommand("wevtutil.exe", $"gp \"{provider}\"");
         }
 
+        /// <summary>
+        /// Extracts a property value from provider metadata text.
+        /// </summary>
+        /// <param name="metadata">Metadata text.</param>
+        /// <param name="propertyName">Property name to search for.</param>
+        /// <returns>Property value if found, otherwise <c>null</c>.</returns>
         private static string GetMetadataProperty(string metadata, string propertyName) {
             string marker = propertyName + ":";
             int startIndex = metadata.IndexOf(marker);
@@ -129,6 +160,12 @@ namespace EventViewerX {
             return metadata.Substring(startIndex, endIndex - startIndex).Trim();
         }
 
+        /// <summary>
+        /// Executes a command line process and returns the standard output.
+        /// </summary>
+        /// <param name="fileName">Executable name.</param>
+        /// <param name="arguments">Command line arguments.</param>
+        /// <returns>Process output.</returns>
         private static string RunCommand(string fileName, string arguments) {
             ProcessStartInfo startInfo = new ProcessStartInfo {
                 FileName = fileName,

--- a/Sources/EventViewerX/Definitions/GroupPolicy.cs
+++ b/Sources/EventViewerX/Definitions/GroupPolicy.cs
@@ -4,7 +4,10 @@
 /// Represents a single Group Policy with its name, ID, and domain.
 /// </summary>
 public class GroupPolicy {
+    /// <summary>Name of the Group Policy Object.</summary>
     public string GpoName { get; set; }
+    /// <summary>Identifier of the Group Policy Object.</summary>
     public string GpoId { get; set; }
+    /// <summary>Domain hosting the Group Policy Object.</summary>
     public string GpoDomain { get; set; }
 }

--- a/Sources/EventViewerX/Definitions/GroupPolicyLinks.cs
+++ b/Sources/EventViewerX/Definitions/GroupPolicyLinks.cs
@@ -4,8 +4,12 @@
 /// Represents a single Group Policy link with its display name, GUID, and distinguished name.
 /// </summary>
 public class GroupPolicyLinks {
+    /// <summary>Display name of the link.</summary>
     public string DisplayName { get; set; } = string.Empty;
+    /// <summary>Unique identifier of the link.</summary>
     public string Guid { get; set; } = string.Empty;
+    /// <summary>Distinguished name of the Active Directory object.</summary>
     public string DistinguishedName { get; set; } = string.Empty;
+    /// <summary>Indicates whether the link is enabled.</summary>
     public bool IsEnabled { get; set; }
 }

--- a/Sources/EventViewerX/Definitions/Keywords.cs
+++ b/Sources/EventViewerX/Definitions/Keywords.cs
@@ -1,4 +1,7 @@
 ﻿namespace EventViewerX;
+/// <summary>
+/// Well known keyword flags for event records.
+/// </summary>
 public enum Keywords : long {
     AuditFailure = (long)4503599627370496,
     AuditSuccess = (long)9007199254740992,

--- a/Sources/EventViewerX/Definitions/KnownLog.cs
+++ b/Sources/EventViewerX/Definitions/KnownLog.cs
@@ -1,5 +1,8 @@
 namespace EventViewerX;
 
+/// <summary>
+/// Enumerates common Windows event logs.
+/// </summary>
 public enum KnownLog {
     Application,
     System,

--- a/Sources/EventViewerX/Definitions/Level.cs
+++ b/Sources/EventViewerX/Definitions/Level.cs
@@ -1,5 +1,8 @@
 ﻿namespace EventViewerX;
 
+/// <summary>
+/// Common event severity levels.
+/// </summary>
 public enum Level {
     Verbose = 5,
     Informational = 4,

--- a/Sources/EventViewerX/Definitions/ParallelOption.cs
+++ b/Sources/EventViewerX/Definitions/ParallelOption.cs
@@ -1,5 +1,8 @@
 ﻿namespace EventViewerX;
 
+/// <summary>
+/// Options controlling parallel processing behaviour.
+/// </summary>
 public enum ParallelOption {
     Disabled,
     Parallel

--- a/Sources/EventViewerX/Definitions/PowerShellEdition.cs
+++ b/Sources/EventViewerX/Definitions/PowerShellEdition.cs
@@ -1,5 +1,8 @@
 namespace EventViewerX;
 
+/// <summary>
+/// Distinguishes between PowerShell editions.
+/// </summary>
 public enum PowerShellEdition {
     PowerShell,
     WindowsPowerShell

--- a/Sources/EventViewerX/EventLogDetails.cs
+++ b/Sources/EventViewerX/EventLogDetails.cs
@@ -2,41 +2,83 @@
 
 namespace EventViewerX;
 
+/// <summary>
+/// Describes configuration and status of a single event log.
+/// </summary>
 public class EventLogDetails {
+    /// <summary>Machine that hosts the log.</summary>
     public string MachineName { get; set; }
+    /// <summary>Name of the log.</summary>
     public string LogName { get; set; }
+    /// <summary>Type of the log.</summary>
     public string LogType { get; set; }
+    /// <summary>Log isolation mode.</summary>
     public EventLogIsolation LogIsolation { get; set; }
+    /// <summary>Indicates whether the log is enabled.</summary>
     public bool IsEnabled { get; set; }
+    /// <summary>Indicates whether the log file reached its maximum size.</summary>
     public bool? IsLogFull { get; set; }
+    /// <summary>Maximum configured size in bytes.</summary>
     public long MaximumSizeInBytes { get; set; }
+    /// <summary>Path to the physical log file.</summary>
     public string LogFilePath { get; set; }
+    /// <summary>Current logging mode.</summary>
     public string LogMode { get; set; }
+    /// <summary>Owning provider name.</summary>
     public string OwningProviderName { get; set; }
+    /// <summary>List of providers registered for the log.</summary>
     public List<string> ProviderNames { get; set; }
+    /// <summary>Provider level mask.</summary>
     public string ProviderLevel { get; set; }
+    /// <summary>Provider keywords mask.</summary>
     public string ProviderKeywords { get; set; }
+    /// <summary>Buffer size used by the provider.</summary>
     public int ProviderBufferSize { get; set; }
+    /// <summary>Minimum number of buffers for the provider.</summary>
     public int ProviderMinimumNumberOfBuffers { get; set; }
+    /// <summary>Maximum number of buffers for the provider.</summary>
     public int ProviderMaximumNumberOfBuffers { get; set; }
+    /// <summary>Provider latency setting.</summary>
     public int ProviderLatency { get; set; }
+    /// <summary>Control GUID for the provider.</summary>
     public string ProviderControlGuid { get; set; }
+    /// <summary>Creation time of the log file.</summary>
     public DateTime? CreationTime { get; set; }
+    /// <summary>Last access time of the log file.</summary>
     public DateTime? LastAccessTime { get; set; }
+    /// <summary>Last write time of the log file.</summary>
     public DateTime? LastWriteTime { get; set; }
+    /// <summary>Current file size in bytes.</summary>
     public long? FileSize { get; set; }
+    /// <summary>Maximum configured file size in bytes.</summary>
     public long? FileSizeMaximum;
+    /// <summary>Current file size in megabytes.</summary>
     public double? FileSizeCurrentMB;
+    /// <summary>Maximum file size in megabytes.</summary>
     public double? FileSizeMaximumMB;
+    /// <summary>Total number of records.</summary>
     public long? RecordCount { get; set; }
+    /// <summary>Oldest record number.</summary>
     public long? OldestRecordNumber { get; set; }
+    /// <summary>Security descriptor of the log.</summary>
     public string SecurityDescriptor { get; set; }
+    /// <summary>Indicates if the log is classic type.</summary>
     public bool IsClassicLog { get; set; }
 
+    /// <summary>Newest event timestamp.</summary>
     public DateTime? NewestEvent;
+    /// <summary>Oldest event timestamp.</summary>
     public DateTime? OldestEvent;
+    /// <summary>Additional log attributes.</summary>
     public int? Attributes { get; set; }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EventLogDetails"/> class.
+    /// </summary>
+    /// <param name="internalLogger">Logger used for warnings.</param>
+    /// <param name="machineName">Name of the computer hosting the log.</param>
+    /// <param name="logConfig">Event log configuration.</param>
+    /// <param name="logInfoObj">Optional log information object.</param>
     public EventLogDetails(InternalLogger internalLogger, string machineName, EventLogConfiguration logConfig, EventLogInformation logInfoObj) {
         LogName = logConfig.LogName;
         LogType = logConfig.LogType.ToString();
@@ -80,6 +122,14 @@ public class EventLogDetails {
         MachineName = machineName;
     }
 
+    /// <summary>
+    /// Converts a numeric size value between units.
+    /// </summary>
+    /// <param name="value">Value to convert.</param>
+    /// <param name="fromUnit">Current unit of measure.</param>
+    /// <param name="toUnit">Destination unit of measure.</param>
+    /// <param name="precision">Number of decimal places.</param>
+    /// <returns>Converted value.</returns>
     private static double ConvertSize(double? value, string fromUnit, string toUnit, int precision) {
         if (!value.HasValue) {
             return 0;

--- a/Sources/EventViewerX/EventRuleAttribute.cs
+++ b/Sources/EventViewerX/EventRuleAttribute.cs
@@ -8,10 +8,19 @@ namespace EventViewerX;
 /// </summary>
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
 public class EventRuleAttribute : Attribute {
+    /// <summary>Event identifiers handled by the rule.</summary>
     public List<int> EventIds { get; }
+    /// <summary>Name of the event log.</summary>
     public string LogName { get; }
+    /// <summary>Associated named event.</summary>
     public NamedEvents NamedEvent { get; }
 
+    /// <summary>
+    /// Initializes a new instance of the attribute.
+    /// </summary>
+    /// <param name="namedEvent">Named event represented by the rule.</param>
+    /// <param name="logName">Log name to watch.</param>
+    /// <param name="eventIds">Event IDs handled by the rule.</param>
     public EventRuleAttribute(NamedEvents namedEvent, string logName, params int[] eventIds) {
         NamedEvent = namedEvent;
         LogName = logName;


### PR DESCRIPTION
## Summary
- document `BinaryWrappers` helper methods
- add XML docs to `EventLogDetails`
- document public members of `EventRuleAttribute`
- annotate various event viewer enums and classes

## Testing
- `dotnet build Sources/EventViewerX.sln -c Release` *(fails: NETSDK1045)*

------
https://chatgpt.com/codex/tasks/task_e_686b6c320450832eb9b1780f09dfbe7f