### PR TITLE
Add XML comments for undocumented events

### DIFF
--- a/Sources/EventViewerX/EventObject.cs
+++ b/Sources/EventViewerX/EventObject.cs
@@ -7,6 +7,9 @@ using System.Xml.Linq;
 using System.Text.RegularExpressions;
 
 namespace EventViewerX {
+    /// <summary>
+    /// Detailed representation of a Windows event record.
+    /// </summary>
     public class EventObject {
         /// <summary>
         /// Time and date when the event was created

--- a/Sources/EventViewerX/EventObjectSlim.cs
+++ b/Sources/EventViewerX/EventObjectSlim.cs
@@ -8,6 +8,9 @@ using EventViewerX.Rules.NPS;
 
 namespace EventViewerX;
 
+/// <summary>
+/// Lightweight representation of an event used for rule processing.
+/// </summary>
 public class EventObjectSlim {
     /// <summary>
     /// Reference to the detailed event object.

--- a/Sources/EventViewerX/Logger/InternalLogger.cs
+++ b/Sources/EventViewerX/Logger/InternalLogger.cs
@@ -159,6 +159,9 @@ public class InternalLogger {
     }
 }
 
+/// <summary>
+/// Event arguments used by <see cref="InternalLogger"/> events.
+/// </summary>
 public class LogEventArgs : EventArgs {
     /// <summary>
     /// Progress percentage

--- a/Sources/EventViewerX/Rules/ActiveDirectory/GroupPolicies/ADGroupPolicyChanges.cs
+++ b/Sources/EventViewerX/Rules/ActiveDirectory/GroupPolicies/ADGroupPolicyChanges.cs
@@ -4,14 +4,23 @@
 /// Summary information for group policy change events.
 /// </summary>
 public class ADGroupPolicyChanges : EventRuleBase {
+    /// <summary>Computer where the change occurred.</summary>
     public string Computer;
+    /// <summary>Description of the action.</summary>
     public string Action;
+    /// <summary>Class of the object modified.</summary>
     public string ObjectClass;
+    /// <summary>Operation type value.</summary>
     public string OperationType;
+    /// <summary>User performing the action.</summary>
     public string Who;
+    /// <summary>Timestamp of the event.</summary>
     public DateTime When;
+    /// <summary>Distinguished name of the GPO.</summary>
     public string GpoName;
+    /// <summary>LDAP display name of the attribute.</summary>
     public string AttributeLDAPDisplayName;
+    /// <summary>Value of the attribute.</summary>
     public string AttributeValue;
     public override List<int> EventIds => new() { 5136, 5137, 5141 };
     public override string LogName => "Security";

--- a/Sources/EventViewerX/Rules/ActiveDirectory/GroupPolicies/ADGroupPolicyEdits.cs
+++ b/Sources/EventViewerX/Rules/ActiveDirectory/GroupPolicies/ADGroupPolicyEdits.cs
@@ -6,13 +6,21 @@ namespace EventViewerX.Rules.ActiveDirectory;
 /// Represents edits made to group policy objects.
 /// </summary>
 public class ADGroupPolicyEdits : EventRuleBase {
+    /// <summary>Computer where the edit occurred.</summary>
     public string Computer;
+    /// <summary>Description of the action.</summary>
     public string Action;
+    /// <summary>Class of the object modified.</summary>
     public string ObjectClass;
+    /// <summary>Operation type value.</summary>
     public string OperationType;
+    /// <summary>User performing the edit.</summary>
     public string Who;
+    /// <summary>Time the edit occurred.</summary>
     public DateTime When;
+    /// <summary>Display name of the GPO.</summary>
     public string GroupPolicyDisplayName;
+    /// <summary>LDAP display name of the attribute.</summary>
     public string AttributeLDAPDisplayName;
     //public string AttributeValue;
     public GroupPolicy GroupPolicy { get; set; }

--- a/Sources/EventViewerX/Rules/ActiveDirectory/GroupPolicies/ADGroupPolicyLinks.cs
+++ b/Sources/EventViewerX/Rules/ActiveDirectory/GroupPolicies/ADGroupPolicyLinks.cs
@@ -49,13 +49,21 @@ namespace EventViewerX.Rules.ActiveDirectory;
 /// </code>
 /// </remarks>
 public class ADGroupPolicyLinks : EventRuleBase {
+    /// <summary>Computer where the change occurred.</summary>
     public string Computer;
+    /// <summary>Description of the operation.</summary>
     public string Action;
+    /// <summary>Type of operation.</summary>
     public string OperationType;
+    /// <summary>User performing the change.</summary>
     public string Who;
+    /// <summary>Event timestamp.</summary>
     public DateTime When;
+    /// <summary>Domain affected.</summary>
     public string DomainName;
+    /// <summary>Type of object linked to.</summary>
     public string LinkedToType;
+    /// <summary>Distinguished name of the linked object.</summary>
     public string LinkedTo;
     // public string AttributeLDAPDisplayName;
     // public string AttributeValue;

--- a/Sources/EventViewerX/Rules/ActiveDirectory/GroupPolicies/GpoCreated.cs
+++ b/Sources/EventViewerX/Rules/ActiveDirectory/GroupPolicies/GpoCreated.cs
@@ -4,10 +4,15 @@
 /// Represents a newly created group policy object event.
 /// </summary>
 public class GpoCreated : EventRuleBase {
+    /// <summary>Computer on which the GPO was created.</summary>
     public string Computer;
+    /// <summary>Description of the action.</summary>
     public string Action;
+    /// <summary>Distinguished name of the new GPO.</summary>
     public string GpoName;
+    /// <summary>User that created the GPO.</summary>
     public string Who;
+    /// <summary>Time the GPO was created.</summary>
     public DateTime When;
     public override List<int> EventIds => new() { 5137 };
     public override string LogName => "Security";

--- a/Sources/EventViewerX/Rules/ActiveDirectory/GroupPolicies/GpoDeleted.cs
+++ b/Sources/EventViewerX/Rules/ActiveDirectory/GroupPolicies/GpoDeleted.cs
@@ -4,10 +4,15 @@
 /// Represents a deleted group policy object event.
 /// </summary>
 public class GpoDeleted : EventRuleBase {
+    /// <summary>Computer where the GPO was deleted.</summary>
     public string Computer;
+    /// <summary>Description of the action.</summary>
     public string Action;
+    /// <summary>Distinguished name of the deleted GPO.</summary>
     public string GpoName;
+    /// <summary>User that deleted the GPO.</summary>
     public string Who;
+    /// <summary>Time the GPO was deleted.</summary>
     public DateTime When;
     public override List<int> EventIds => new() { 5141 };
     public override string LogName => "Security";

--- a/Sources/EventViewerX/Rules/ActiveDirectory/GroupPolicies/GpoModified.cs
+++ b/Sources/EventViewerX/Rules/ActiveDirectory/GroupPolicies/GpoModified.cs
@@ -4,12 +4,19 @@
 /// Represents a modified group policy object event.
 /// </summary>
 public class GpoModified : EventRuleBase {
+    /// <summary>Computer where the modification occurred.</summary>
     public string Computer;
+    /// <summary>Description of the action.</summary>
     public string Action;
+    /// <summary>Distinguished name of the modified GPO.</summary>
     public string GpoName;
+    /// <summary>LDAP display name of the changed attribute.</summary>
     public string AttributeLDAPDisplayName;
+    /// <summary>New value of the attribute.</summary>
     public string AttributeValue;
+    /// <summary>User responsible for the modification.</summary>
     public string Who;
+    /// <summary>Time of the modification.</summary>
     public DateTime When;
     public override List<int> EventIds => new() { 5136 };
     public override string LogName => "Security";

--- a/Sources/EventViewerX/Rules/Windows/BitLockerKeyChange.cs
+++ b/Sources/EventViewerX/Rules/Windows/BitLockerKeyChange.cs
@@ -14,14 +14,23 @@ public class BitLockerKeyChange : EventRuleBase {
         // Simple rule - always handle if event ID and log name match
         return true;
     }
+    /// <summary>Computer where the key operation happened.</summary>
     public string Computer;
+    /// <summary>Description of the action.</summary>
     public string Action;
+    /// <summary>Volume type.</summary>
     public BitLockerVolumeType? Volume;
+    /// <summary>Protector type used.</summary>
     public BitLockerProtectorType? ProtectorType;
+    /// <summary>Master key identifier.</summary>
     public string MasterKeyId;
+    /// <summary>Recovery key identifier.</summary>
     public string RecoveryKeyId;
+    /// <summary>Server where recovery key was stored.</summary>
     public string RecoveryServer;
+    /// <summary>User responsible for the change.</summary>
     public string Who;
+    /// <summary>Time of the event.</summary>
     public DateTime When;
 
     public BitLockerKeyChange(EventObject eventObject) : base(eventObject) {

--- a/Sources/EventViewerX/Rules/Windows/DfsReplicationError.cs
+++ b/Sources/EventViewerX/Rules/Windows/DfsReplicationError.cs
@@ -13,9 +13,13 @@ public class DfsReplicationError : EventRuleBase {
         return true;
     }
 
+    /// <summary>Replication group affected.</summary>
     public string ReplicationGroup;
+    /// <summary>Error code reported.</summary>
     public string ErrorCode;
+    /// <summary>Replication partner.</summary>
     public string Partner;
+    /// <summary>Event time.</summary>
     public DateTime When;
 
     public DfsReplicationError(EventObject eventObject) : base(eventObject) {

--- a/Sources/EventViewerX/Rules/Windows/FirewallRuleChange.cs
+++ b/Sources/EventViewerX/Rules/Windows/FirewallRuleChange.cs
@@ -13,10 +13,15 @@ public class FirewallRuleChange : EventRuleBase {
         // Simple rule - always handle if event ID and log name match
         return true;
     }
+    /// <summary>Computer where the rule was modified.</summary>
     public string Computer;
+    /// <summary>Description of the action.</summary>
     public string Action;
+    /// <summary>Name of the rule.</summary>
     public string RuleName;
+    /// <summary>Firewall profile that changed.</summary>
     public string ProfileChanged;
+    /// <summary>Time the event occurred.</summary>
     public DateTime When;
 
     public FirewallRuleChange(EventObject eventObject) : base(eventObject) {

--- a/Sources/EventViewerX/Rules/Windows/OSBugCheck.cs
+++ b/Sources/EventViewerX/Rules/Windows/OSBugCheck.cs
@@ -14,14 +14,23 @@ public class OSBugCheck : EventRuleBase {
         return true;
     }
 
+    /// <summary>Computer where the bugcheck occurred.</summary>
     public string Computer;
+    /// <summary>Bugcheck code.</summary>
     public string BugCheckCode;
+    /// <summary>First bugcheck parameter.</summary>
     public string Parameter1;
+    /// <summary>Second bugcheck parameter.</summary>
     public string Parameter2;
+    /// <summary>Third bugcheck parameter.</summary>
     public string Parameter3;
+    /// <summary>Fourth bugcheck parameter.</summary>
     public string Parameter4;
+    /// <summary>Path to created dump file.</summary>
     public string DumpFile;
+    /// <summary>Report identifier.</summary>
     public string ReportId;
+    /// <summary>Event time.</summary>
     public DateTime When;
 
     public OSBugCheck(EventObject eventObject) : base(eventObject) {

--- a/Sources/EventViewerX/Rules/Windows/OSTimeChange.cs
+++ b/Sources/EventViewerX/Rules/Windows/OSTimeChange.cs
@@ -14,12 +14,19 @@ public class OSTimeChange : EventRuleBase {
         // Simple rule - always handle if event ID and log name match
         return true;
     }
+    /// <summary>Computer where the time was changed.</summary>
     public string Computer;
+    /// <summary>Description of the event.</summary>
     public string Action;
+    /// <summary>Machine affected by the change.</summary>
     public string ObjectAffected;
+    /// <summary>Previous system time.</summary>
     public string PreviousTime;
+    /// <summary>New system time.</summary>
     public string NewTime;
+    /// <summary>User who changed the time.</summary>
     public string Who;
+    /// <summary>Timestamp of the event.</summary>
     public DateTime When;
 
     public OSTimeChange(EventObject eventObject) : base(eventObject) {

--- a/Sources/EventViewerX/Rules/Windows/ScheduledTaskCreated.cs
+++ b/Sources/EventViewerX/Rules/Windows/ScheduledTaskCreated.cs
@@ -13,10 +13,15 @@ public class ScheduledTaskCreated : EventRuleBase {
         // Simple rule - always handle if event ID and log name match
         return true;
     }
+    /// <summary>Computer where the task was created.</summary>
     public string Computer;
+    /// <summary>Name of the created task.</summary>
     public string TaskName;
+    /// <summary>Author of the task definition.</summary>
     public string Author;
+    /// <summary>Creation timestamp read from the task XML.</summary>
     public DateTime? Created;
+    /// <summary>Time the event occurred.</summary>
     public DateTime When;
 
     public ScheduledTaskCreated(EventObject eventObject) : base(eventObject) {

--- a/Sources/EventViewerX/Rules/Windows/ScheduledTaskDeleted.cs
+++ b/Sources/EventViewerX/Rules/Windows/ScheduledTaskDeleted.cs
@@ -13,9 +13,13 @@ public class ScheduledTaskDeleted : EventRuleBase {
         // Simple rule - always handle if event ID and log name match
         return true;
     }
+    /// <summary>Computer where the task was deleted.</summary>
     public string Computer;
+    /// <summary>Name of the task.</summary>
     public string TaskName;
+    /// <summary>User that deleted the task.</summary>
     public string Who;
+    /// <summary>Time the event occurred.</summary>
     public DateTime When;
 
     public ScheduledTaskDeleted(EventObject eventObject) : base(eventObject) {

--- a/Sources/EventViewerX/Rules/Windows/WindowsUpdateFailure.cs
+++ b/Sources/EventViewerX/Rules/Windows/WindowsUpdateFailure.cs
@@ -13,9 +13,13 @@ public class WindowsUpdateFailure : EventRuleBase {
         // Simple rule - always handle if event ID and log name match
         return true;
     }
+    /// <summary>Computer where the update failed.</summary>
     public string Computer;
+    /// <summary>KB article number of the update.</summary>
     public string KB;
+    /// <summary>Reason of the failure.</summary>
     public string Reason;
+    /// <summary>Time the event occurred.</summary>
     public DateTime When;
 
     public WindowsUpdateFailure(EventObject eventObject) : base(eventObject) {

--- a/Sources/EventViewerX/Settings.cs
+++ b/Sources/EventViewerX/Settings.cs
@@ -1,28 +1,36 @@
 namespace EventViewerX;
 
+/// <summary>
+/// Provides basic logging and threading configuration for the library.
+/// </summary>
 public class Settings {
     public static InternalLogger _logger = new InternalLogger();
 
+    /// <summary>When set, error messages are written to the console.</summary>
     public bool Error {
         get => _logger.IsError;
         set => _logger.IsError = value;
     }
 
+    /// <summary>Enables verbose output.</summary>
     public bool Verbose {
         get => _logger.IsVerbose;
         set => _logger.IsVerbose = value;
     }
 
+    /// <summary>Enables warning output.</summary>
     public bool Warning {
         get => _logger.IsWarning;
         set => _logger.IsWarning = value;
     }
 
+    /// <summary>Enables progress reporting.</summary>
     public bool Progress {
         get => _logger.IsProgress;
         set => _logger.IsProgress = value;
     }
 
+    /// <summary>Enables debug output.</summary>
     public bool Debug {
         get => _logger.IsDebug;
         set => _logger.IsDebug = value;

--- a/Sources/EventViewerX/TimeHelper.cs
+++ b/Sources/EventViewerX/TimeHelper.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 
 namespace EventViewerX {
+    /// <summary>
+    /// Commonly used time ranges for event queries.
+    /// </summary>
     public enum TimePeriod {
         PastHour,
         CurrentHour,
@@ -33,6 +36,11 @@ namespace EventViewerX {
     }
 
     internal static class TimeHelper {
+        /// <summary>
+        /// Converts a <see cref="TimePeriod"/> to start and end timestamps.
+        /// </summary>
+        /// <param name="timePeriod">Time range to convert.</param>
+        /// <returns>Tuple describing the time range.</returns>
         internal static (DateTime? StartTime, DateTime? EndTime, TimeSpan? LastPeriod) GetTimePeriod(TimePeriod timePeriod) {
             DateTime now = DateTime.Now;
             DateTime? startTime = null;

--- a/Sources/EventViewerX/WatchEvents.cs
+++ b/Sources/EventViewerX/WatchEvents.cs
@@ -6,10 +6,16 @@ using System.Linq;
 using System.Threading;
 
 namespace EventViewerX {
+    /// <summary>
+    /// Watches event logs and invokes callbacks when matching events appear.
+    /// </summary>
     public class WatchEvents : Settings, IDisposable {
+        /// <summary>Global count of all events detected.</summary>
         public static volatile int NumberOfEventsFound = 0;
         private int _eventsFound;
+        /// <summary>Number of events captured during the current watch session.</summary>
         public int EventsFound => _eventsFound;
+        /// <summary>Time when event watching started.</summary>
         public DateTime StartTime { get; private set; }
         /// <summary>
         /// List of event IDs to watch for
@@ -41,12 +47,26 @@ namespace EventViewerX {
 
         private string _machineName;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WatchEvents"/> class.
+        /// </summary>
+        /// <param name="internalLogger">Optional logger for verbose output.</param>
         public WatchEvents(InternalLogger internalLogger = null) {
             if (internalLogger != null) {
                 _logger = internalLogger;
             }
         }
 
+        /// <summary>
+        /// Starts watching for specified event IDs.
+        /// </summary>
+        /// <param name="machineName">Target machine name.</param>
+        /// <param name="logName">Event log name.</param>
+        /// <param name="eventId">Event identifiers to monitor.</param>
+        /// <param name="eventAction">Callback when event is detected.</param>
+        /// <param name="cancellationToken">Cancellation token to stop watching.</param>
+        /// <param name="staging">Whether to use staging mode.</param>
+        /// <param name="enabledBy">Account that enabled staging.</param>
         public void Watch(string machineName, string logName, List<int> eventId, Action<EventObject> eventAction = null, CancellationToken cancellationToken = default, bool staging = false, string enabledBy = null) {
             NumberOfEventsFound = 0;
             _eventsFound = 0;
@@ -101,6 +121,9 @@ namespace EventViewerX {
             }
         }
 
+        /// <summary>
+        /// Stops watching and cleans up resources.
+        /// </summary>
         public void Dispose() {
             if (_eventLogWatcher != null) {
                 _eventLogWatcher.EventRecordWritten -= DetectEventsLogCallback;


### PR DESCRIPTION
## Summary
- document watch events logic
- add class docs for event objects
- document logging event args
- add summaries and parameter docs for settings
- document time utilities
- document event rule properties across multiple rule files

## Testing
- `dotnet test Sources/EventViewerX.sln` *(fails: NETSDK1045)*

------
https://chatgpt.com/codex/tasks/task_e_686b801105f4832ebbb85fc80b887092