### PR TITLE
Fix cleanup target for build output

### DIFF
--- a/Sources/PSEventViewer/PSEventViewer.csproj
+++ b/Sources/PSEventViewer/PSEventViewer.csproj
@@ -50,7 +50,7 @@
         <Delete Files="$(OutDir)System.Management.Automation.dll"
                 Condition="Exists('$(OutDir)System.Management.Automation.dll')" />
         <Delete Files="$(OutDir)System.Management.dll"
-                Condition="Exists('$(OutDir)System.Management.Automation.dll')" />
+                Condition="Exists('$(OutDir)System.Management.dll')" />
     </Target>
 
     <PropertyGroup>
@@ -72,5 +72,4 @@
             DestinationFiles="$(PublishDir)$(AssemblyName).dll-Help.xml"
             Condition="Exists('$(OutputPath)$(AssemblyName).dll-Help.xml')" />
     </Target>
-
 </Project>


### PR DESCRIPTION
## Summary
- ensure `System.Management.dll` deletion checks its own file

## Testing
- `dotnet build Sources/EventViewerX/EventViewerX.csproj -c Release -p:TargetFrameworks=net8.0`
- `dotnet msbuild Sources/PSEventViewer/PSEventViewer.csproj /p:TargetFramework=net8.0 /p:BuildProjectReferences=false`
- `find Sources/PSEventViewer/bin/Debug -name "System.Management*.dll"`

------
https://chatgpt.com/codex/tasks/task_e_686edef1db44832e859b4c71650c5a5f