### PR TITLE
Add logging for ExtractData errors

### DIFF
--- a/Sources/EventViewerX.Tests/TestPowerShellScripts.cs
+++ b/Sources/EventViewerX.Tests/TestPowerShellScripts.cs
@@ -1,0 +1,22 @@
+using System.Reflection;
+using Xunit;
+
+namespace EventViewerX.Tests {
+    public class TestPowerShellScripts {
+        [Fact]
+        public void ExtractDataLogsWarning() {
+            var method = typeof(SearchEvents).GetMethod("ExtractData", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(method);
+            string? message = null;
+            EventHandler<LogEventArgs> handler = (_, e) => message = e.FullMessage;
+            Settings._logger.OnWarningMessage += handler;
+            try {
+                var result = method!.Invoke(null, new object?[] { null, "Test" });
+                Assert.Null(result);
+                Assert.NotNull(message);
+            } finally {
+                Settings._logger.OnWarningMessage -= handler;
+            }
+        }
+    }
+}

--- a/Sources/EventViewerX/SearchEvents.PowerShellScripts.cs
+++ b/Sources/EventViewerX/SearchEvents.PowerShellScripts.cs
@@ -167,7 +167,8 @@ namespace EventViewerX {
                 XNamespace ns = element.GetDefaultNamespace();
                 return element.Descendants(ns + "Data")
                     .FirstOrDefault(e => (string)e.Attribute("Name") == name)?.Value;
-            } catch {
+            } catch (Exception ex) {
+                Settings._logger.WriteWarning($"Failed extracting '{name}' data. Error: {ex.Message}");
                 return null;
             }
         }


### PR DESCRIPTION
## Summary
- log warning when ExtractData fails
- cover ExtractData error logging with new test

## Testing
- `dotnet test Sources/EventViewerX.Tests/EventViewerX.Tests.csproj -c Release -p:TargetFramework=net8.0 -p:TargetFrameworks=net8.0`
- `pwsh -NoLogo -NoProfile -Command ./PSEventViewer.Tests.ps1` *(fails: Write-Color not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ede22d19c832e91bf9594de7d5da0