### PR TITLE
Fix streaming test to use startup event

### DIFF
--- a/Sources/EventViewerX.Tests/TestStreaming.cs
+++ b/Sources/EventViewerX.Tests/TestStreaming.cs
@@ -18,7 +18,9 @@ namespace EventViewerX.Tests {
         [Fact]
         public async Task NamedEventsStreamFirstEvent() {
             if (!OperatingSystem.IsWindows()) return;
-            await foreach (var _ in SearchEvents.FindEventsByNamedEvents([NamedEvents.OSCrash], new List<string> { Environment.MachineName }, maxEvents: 1)) {
+            await foreach (var _ in SearchEvents.FindEventsByNamedEvents([
+                NamedEvents.OSStartupSecurity
+            ], new List<string> { Environment.MachineName }, maxEvents: 1)) {
                 return;
             }
             Assert.Fail("No events were returned from FindEventsByNamedEvents.");


### PR DESCRIPTION
## Summary
- fix `NamedEventsStreamFirstEvent` to query `OSStartupSecurity` instead of `OSCrash`
- ensure tests run with events available on typical Windows systems

## Testing
- `dotnet build Sources/EventViewerX.sln --configuration Debug`
- `dotnet test Sources/EventViewerX.sln --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_686fbac77dbc832ea13073986f4363dc