### PR TITLE
Handle XML parse errors

### DIFF
--- a/Sources/EventViewerX.Tests/TestPowerShellScripts.cs
+++ b/Sources/EventViewerX.Tests/TestPowerShellScripts.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Collections.Generic;
 using Xunit;
 
 namespace EventViewerX.Tests {
@@ -13,6 +14,23 @@ namespace EventViewerX.Tests {
             try {
                 var result = method!.Invoke(null, new object?[] { null, "Test" });
                 Assert.Null(result);
+                Assert.NotNull(message);
+            } finally {
+                Settings._logger.OnWarningMessage -= handler;
+            }
+        }
+
+        [Fact]
+        public void GetAllDataLogsWarning() {
+            var method = typeof(SearchEvents).GetMethod("GetAllData", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(method);
+            string? message = null;
+            EventHandler<LogEventArgs> handler = (_, e) => message = e.FullMessage;
+            Settings._logger.OnWarningMessage += handler;
+            try {
+                var result = method!.Invoke(null, new object?[] { null });
+                Assert.NotNull(result);
+                Assert.Empty((Dictionary<string, string?>)result!);
                 Assert.NotNull(message);
             } finally {
                 Settings._logger.OnWarningMessage -= handler;

--- a/Sources/EventViewerX/SearchEvents.PowerShellScripts.cs
+++ b/Sources/EventViewerX/SearchEvents.PowerShellScripts.cs
@@ -184,7 +184,8 @@ namespace EventViewerX {
                         result[key] = data.Value;
                     }
                 }
-            } catch {
+            } catch (Exception ex) {
+                Settings._logger.WriteWarning($"Failed parsing event data. Error: {ex.Message}");
             }
             return result;
         }


### PR DESCRIPTION
## Summary
- log exceptions from GetAllData when parsing fails
- add unit test verifying GetAllData logs warnings

## Testing
- `dotnet test Sources/EventViewerX.Tests/EventViewerX.Tests.csproj --verbosity minimal -p:TargetFrameworks=net8.0` *(fails: The current .NET SDK does not support targeting .NET 9.0)*
- `pwsh -NoProfile -NoLogo -Command ./PSEventViewer.Tests.ps1` *(fails: could not install required modules)*

------
https://chatgpt.com/codex/tasks/task_e_686fd8904730832e9148a96c725f3345