### PR TITLE
Fix ExtractData logging

### DIFF
--- a/Sources/EventViewerX/SearchEvents.PowerShellScripts.cs
+++ b/Sources/EventViewerX/SearchEvents.PowerShellScripts.cs
@@ -168,7 +168,7 @@ namespace EventViewerX {
                 return element.Descendants(ns + "Data")
                     .FirstOrDefault(e => (string)e.Attribute("Name") == name)?.Value;
             } catch (Exception ex) {
-                Settings._logger.WriteWarning($"Failed extracting '{name}' data. Error: {ex.Message}");
+                Settings._logger.WriteWarning($"Failed extracting '{name}' data. Exception: {ex}");
                 return null;
             }
         }


### PR DESCRIPTION
## Summary
- log the caught exception when extracting event data

## Testing
- `dotnet test Sources/EventViewerX.Tests/EventViewerX.Tests.csproj -p:TargetFramework=net8.0 -p:TargetFrameworks=net8.0 --verbosity minimal`
- `pwsh -NoLogo -NoProfile -Command "& './PSEventViewer.Tests.ps1'"` *(fails: module downloads blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686fd86d77a4832e8d9370e6293f9fec