### PR TITLE
Remove ambiguous positional parameter

### DIFF
--- a/Sources/PSEventViewer/CmdletGetEVXEvent.cs
+++ b/Sources/PSEventViewer/CmdletGetEVXEvent.cs
@@ -47,7 +47,7 @@ public sealed class CmdletGetEVXEvent : AsyncPSCmdlet {
     /// Specific event record identifiers to retrieve.
     /// </summary>
     [Alias("RecordId")]
-    [Parameter(Mandatory = false, Position = 1, ParameterSetName = "RecordId")]
+    [Parameter(Mandatory = false, ParameterSetName = "RecordId")]
     public List<long> EventRecordId = null;
 
     /// <summary>

--- a/Tests/Get-EVXEvent.Tests.ps1
+++ b/Tests/Get-EVXEvent.Tests.ps1
@@ -169,3 +169,11 @@ Describe 'Get-EVXEvent - Parameter validation' {
         { Get-EVXEvent -LogName 'Application' -NumberOfThreads 0 } | Should -Throw
     }
 }
+
+Describe 'Get-EVXEvent - Positional EventId' {
+    It 'Allows positional EventId without ambiguity' {
+        $events = Get-EVXEvent 'Application' 5617 -MaxEvents 1 -AsArray
+        $events | Should -HaveCount 1
+        $events[0].ID | Should -Be 5617
+    }
+}


### PR DESCRIPTION
## Summary
- adjust parameter attributes for `EventRecordId`
- test positional EventId handling

## Testing
- `dotnet build Sources/EventViewerX/EventViewerX.csproj -c Release -p:TargetFrameworks=net8.0`
- `dotnet build Sources/PSEventViewer/PSEventViewer.csproj -c Release -p:TargetFrameworks=net8.0`
- `pwsh -NoLogo -NoProfile -Command ./PSEventViewer.Tests.ps1` *(fails: Write-Color missing)*

------
https://chatgpt.com/codex/tasks/task_e_686fd8d849a4832e8e1d372146f011e2