### PR TITLE
Ensure case-insensitive XML data parsing

### DIFF
--- a/Sources/EventViewerX.Tests/TestParseXml.cs
+++ b/Sources/EventViewerX.Tests/TestParseXml.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.Serialization;
+using Xunit;
+
+namespace EventViewerX.Tests {
+    public class TestParseXml {
+        [Fact]
+        public void DataDictionaryIsCaseInsensitive() {
+            const string xml = "<Event><EventData><Data Name='Key'>Value</Data></EventData></Event>";
+            var obj = (EventObject)FormatterServices.GetUninitializedObject(typeof(EventObject));
+            var method = typeof(EventObject).GetMethod("ParseXML", BindingFlags.NonPublic | BindingFlags.Instance)!
+                .MakeGenericMethod(typeof(Dictionary<string, string>));
+            var result = (Dictionary<string, string>)method.Invoke(obj, new object[] { xml })!;
+            Assert.Equal("Value", result["Key"]);
+            Assert.Equal("Value", result["key"]);
+        }
+    }
+}

--- a/Sources/EventViewerX/EventObject.cs
+++ b/Sources/EventViewerX/EventObject.cs
@@ -315,7 +315,9 @@ namespace EventViewerX {
         /// <param name="xmlData">The XML data.</param>
         /// <returns></returns>
         private T ParseXML<T>(string xmlData) where T : IDictionary<string, string>, new() {
-            T data = new();
+            T data = typeof(T) == typeof(Dictionary<string, string>)
+                ? (T)(object)new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                : new();
 
             // Parse the XML data into an XElement
             XElement root;


### PR DESCRIPTION
## Summary
- use `StringComparer.OrdinalIgnoreCase` when building event data dictionaries
- test XML dictionary ignores key casing

## Testing
- `dotnet msbuild Sources/EventViewerX.Tests/EventViewerX.Tests.csproj /p:TargetFramework=net8.0 /t:Build`
- `dotnet vstest Sources/EventViewerX.Tests/bin/Debug/net8.0/EventViewerX.Tests.dll`
- `pwsh -NoLogo -NoProfile -Command ./PSEventViewer.Tests.ps1` *(fails: module install errors)*

------
https://chatgpt.com/codex/tasks/task_e_686fd89a7a24832ea19e9f1cbbfeb6cc