### PR TITLE
Add logging for callback exceptions

### DIFF
--- a/Sources/EventViewerX.Tests/TestWatcherManager.cs
+++ b/Sources/EventViewerX.Tests/TestWatcherManager.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.Serialization;
+using Xunit;
+
+namespace EventViewerX.Tests {
+    public class TestWatcherManager {
+        [Fact]
+        public void OnEventLogsWarningOnException() {
+            var info = (WatcherInfo)Activator.CreateInstance(typeof(WatcherInfo),
+                BindingFlags.Instance | BindingFlags.NonPublic, null,
+                new object[] {
+                    "test", Environment.MachineName, "Application", new List<int> { 1 },
+                    new List<NamedEvents>(), new Action<EventObject>(_ => throw new InvalidOperationException("fail")),
+                    1, false, false, 0, null
+                }, null)!;
+
+            Exception? captured = null;
+            info.ActionException += (_, ex) => captured = ex;
+            string? message = null;
+            EventHandler<LogEventArgs> handler = (_, e) => message = e.FullMessage;
+            Settings._logger.OnWarningMessage += handler;
+            try {
+                var dummy = (EventObject)FormatterServices.GetUninitializedObject(typeof(EventObject));
+                var method = typeof(WatcherInfo).GetMethod("OnEvent", BindingFlags.Instance | BindingFlags.NonPublic)!;
+                method.Invoke(info, new object[] { dummy });
+                Assert.NotNull(captured);
+                Assert.Contains("fail", captured!.Message);
+                Assert.NotNull(message);
+            } finally {
+                Settings._logger.OnWarningMessage -= handler;
+            }
+        }
+    }
+}

--- a/Sources/EventViewerX/WatcherManager.cs
+++ b/Sources/EventViewerX/WatcherManager.cs
@@ -55,18 +55,34 @@ namespace EventViewerX {
             }
         }
 
+        /// <summary>
+        /// Invokes the user provided callback when a matching event is detected.
+        /// </summary>
+        /// <param name="obj">Event object passed to the callback.</param>
         private void OnEvent(EventObject obj) {
+            Exception? exCaught = null;
             try {
                 Action?.Invoke(obj);
-            } catch {
-                // ignore user errors
+            } catch (Exception ex) {
+                exCaught = ex;
+                Settings._logger.WriteWarning("OnEvent callback threw: {0}", ex.Message.Trim());
             }
+
             if (StopOnMatch) {
                 Stop();
             } else if (StopAfter > 0 && Watcher.EventsFound >= StopAfter) {
                 Stop();
             }
+
+            if (exCaught != null) {
+                ActionException?.Invoke(this, exCaught);
+            }
         }
+
+        /// <summary>
+        /// Occurs when the callback passed to <see cref="StartWatcher"/> throws an exception.
+        /// </summary>
+        public event EventHandler<Exception>? ActionException;
 
         public void Stop() {
             Cancellation.Cancel();


### PR DESCRIPTION
## Summary
- catch exceptions thrown by user callbacks in `WatcherManager`
- log caught exceptions as warnings and expose via new `ActionException` event
- test warning log behavior

## Testing
- `dotnet test Sources/EventViewerX.sln -p:TargetFramework=net8.0 -p:SkipUnsupportedTFMs=true` *(fails: NETSDK1045 - .NET 9.0 SDK missing)*
- `pwsh -NoLogo -NoProfile -Command 'Invoke-Pester -Configuration @{Run=@{Exit=$false}}'` *(fails: Invoke-Pester not found)*

------
https://chatgpt.com/codex/tasks/task_e_687019177f20832e9d39308cba7b8908