### PR TITLE
Prevent duplicate watchers

### DIFF
--- a/Sources/EventViewerX.Examples/Examples.Watchers.cs
+++ b/Sources/EventViewerX.Examples/Examples.Watchers.cs
@@ -74,5 +74,34 @@ namespace EventViewerX.Examples {
             Thread.Sleep(TimeSpan.FromSeconds(15));
             Console.WriteLine($"Ended at {watcher.EndTime}");
         }
+
+        public static void WatchDuplicateName() {
+            var first = WatcherManager.StartWatcher(
+                "duplicate",
+                Environment.MachineName,
+                "Application",
+                new List<int> { 1 },
+                new List<NamedEvents>(),
+                _ => { },
+                1,
+                false,
+                false,
+                0,
+                null);
+            var second = WatcherManager.StartWatcher(
+                "duplicate",
+                Environment.MachineName,
+                "Application",
+                new List<int> { 1 },
+                new List<NamedEvents>(),
+                _ => { },
+                1,
+                false,
+                false,
+                0,
+                null);
+            Console.WriteLine(first == second ? "Same watcher" : "Different watcher");
+            WatcherManager.StopAll();
+        }
     }
 }

--- a/Sources/EventViewerX.Tests/TestWatcherManager.cs
+++ b/Sources/EventViewerX.Tests/TestWatcherManager.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Collections.Concurrent;
+using Xunit;
+
+namespace EventViewerX.Tests {
+    public class TestWatcherManager {
+        [Fact]
+        public void StartWatcherReturnsExistingInstance() {
+            var first = WatcherManager.StartWatcher(
+                "unit", Environment.MachineName, "Application", new List<int>(), new List<NamedEvents>(), _ => { }, 1, false, false, 0, null);
+            var second = WatcherManager.StartWatcher(
+                "unit", Environment.MachineName, "Application", new List<int>(), new List<NamedEvents>(), _ => { }, 1, false, false, 0, null);
+            Assert.Same(first, second);
+            WatcherManager.StopAll();
+        }
+
+        [Fact]
+        public void StartWatcherThrowsWhenDuplicatesExist() {
+            var field = typeof(WatcherManager).GetField("_watchers", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(field);
+            var dict = (ConcurrentDictionary<Guid, WatcherInfo>)field!.GetValue(null)!;
+            var watcher1 = new WatcherInfo("dup", Environment.MachineName, "Application", new List<int>(), new List<NamedEvents>(), _ => { }, 1, false, false, 0, null);
+            var watcher2 = new WatcherInfo("dup", Environment.MachineName, "Application", new List<int>(), new List<NamedEvents>(), _ => { }, 1, false, false, 0, null);
+            dict.TryAdd(Guid.NewGuid(), watcher1);
+            dict.TryAdd(Guid.NewGuid(), watcher2);
+
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+                WatcherManager.StartWatcher("dup", Environment.MachineName, "Application", new List<int>(), new List<NamedEvents>(), _ => { }, 1, false, false, 0, null));
+            Assert.Contains("Multiple watchers", ex.Message);
+            WatcherManager.StopAll();
+        }
+    }
+}

--- a/Sources/EventViewerX/WatcherManager.cs
+++ b/Sources/EventViewerX/WatcherManager.cs
@@ -87,6 +87,16 @@ namespace EventViewerX {
         private static readonly ConcurrentDictionary<Guid, WatcherInfo> _watchers = new();
 
         public static WatcherInfo StartWatcher(string? name, string machineName, string logName, List<int> eventIds, List<NamedEvents> namedEvents, Action<EventObject> action, int numberOfThreads, bool staging, bool stopOnMatch, int stopAfter, TimeSpan? timeout) {
+            if (!string.IsNullOrEmpty(name)) {
+                var matches = GetWatchers(name).ToList();
+                if (matches.Count > 0) {
+                    if (matches.Count == 1) {
+                        return matches[0];
+                    }
+                    throw new InvalidOperationException($"Multiple watchers with name '{name}' already exist.");
+                }
+            }
+
             var info = new WatcherInfo(name ?? string.Empty, machineName, logName, eventIds, namedEvents, action, numberOfThreads, staging, stopOnMatch, stopAfter, timeout);
             if (_watchers.TryAdd(info.Id, info)) {
                 info.Start();


### PR DESCRIPTION
## Summary
- check for duplicate names before starting a watcher
- add duplicate watcher example
- add WatcherManager tests

## Testing
- `dotnet test Sources/EventViewerX.sln --no-build --verbosity normal`
- `pwsh -NoLogo -NoProfile -Command ./PSEventViewer.Tests.ps1` *(fails: Write-Color cmdlet missing)*

------
https://chatgpt.com/codex/tasks/task_e_6870192b98a0832e85a894c56635a04e