### PR TITLE
Update logging strings in QueryLog

### DIFF
--- a/Sources/EventViewerX/SearchEvents.QueryLog.cs
+++ b/Sources/EventViewerX/SearchEvents.QueryLog.cs
@@ -273,7 +273,7 @@ public partial class SearchEvents : Settings {
             startTime = times.StartTime;
             endTime = times.EndTime;
             lastPeriod = times.LastPeriod;
-            _logger.WriteVerbose("Time period: " + timePeriod + ", time start: " + startTime + ", time end: " + endTime, " lastPeriod: " + lastPeriod);
+            _logger.WriteVerbose($"Time period: {timePeriod}, time start: {startTime}, time end: {endTime}, lastPeriod: {lastPeriod}");
         }
 
         StringBuilder queryString = new StringBuilder($"<QueryList><Query Id='0' Path='{logName}'><Select Path='{logName}'>*[System[");
@@ -359,7 +359,7 @@ public partial class SearchEvents : Settings {
             machineNames = new List<string> { null };
             _logger.WriteVerbose("No machine names provided, querying the local machine.");
         } else {
-            _logger.WriteVerbose("Machine names provided. Creating tasks for each machine on the list: " + string.Join(", ", machineNames));
+            _logger.WriteVerbose($"Machine names provided. Creating tasks for each machine on the list: {string.Join(", ", machineNames)}");
         }
         var semaphore = new SemaphoreSlim(maxThreads);
         var results = new BlockingCollection<EventObject>();
@@ -425,12 +425,12 @@ public partial class SearchEvents : Settings {
         return Task.Run(async () => {
             await semaphore.WaitAsync(cancellationToken);
             try {
-                _logger.WriteVerbose($"Querying log on machine: {machineName}, logName: {logName}, event ids: " + string.Join(", ", eventIds ?? new List<int>()));
+                _logger.WriteVerbose($"Querying log on machine: {machineName}, logName: {logName}, event ids: {string.Join(", ", eventIds ?? new List<int>())}");
                 foreach (var result in QueryLogEnumerable(logName, eventIds, machineName, providerName, keywords, level, startTime, endTime, userId, maxEvents, eventRecordId, timePeriod, cancellationToken)) {
                     if (cancellationToken.IsCancellationRequested) break;
                     results.Add(result, cancellationToken);
                 }
-                _logger.WriteVerbose("Querying log on machine: " + machineName + " completed.");
+                _logger.WriteVerbose($"Querying log on machine: {machineName} completed.");
             } finally {
                 semaphore.Release();
             }
@@ -450,13 +450,13 @@ public partial class SearchEvents : Settings {
             try {
                 Parallel.ForEach(machineNames, options, machineName => {
                     try {
-                        _logger.WriteVerbose("Starting task for machine: " + machineName);
+                        _logger.WriteVerbose($"Starting task for machine: {machineName}");
                         var queryResults = QueryLog(logName, eventIds, machineName, providerName, keywords, level, startTime, endTime, userId, maxEvents, eventRecordId, cancellationToken: cancellationToken);
                         foreach (var result in queryResults) {
                             if (cancellationToken.IsCancellationRequested) break;
                             results.Add(result, cancellationToken);
                         }
-                        _logger.WriteVerbose("Finished task for machine: " + machineName);
+                        _logger.WriteVerbose($"Finished task for machine: {machineName}");
                     } catch (Exception ex) {
                         exceptions.Enqueue(ex);
                     }


### PR DESCRIPTION
## Summary
- refactor logging in `SearchEvents.QueryLog` to use interpolated strings

## Testing
- `dotnet build Sources/EventViewerX/EventViewerX.csproj -c Release -p:TargetFrameworks=net8.0`
- `dotnet test Sources/EventViewerX.Tests/EventViewerX.Tests.csproj -c Release -p:TargetFrameworks=net8.0` *(fails: No test is available)*
- `pwsh -NoLogo -NoProfile -Command ./PSEventViewer.Tests.ps1` *(fails: required modules missing)*

------
https://chatgpt.com/codex/tasks/task_e_6870193ece34832eaaa98a5b1e9f0283