### PR TITLE
Cache machine FQDN lookup

### DIFF
--- a/Sources/EventViewerX.Tests/TestFqdnCache.cs
+++ b/Sources/EventViewerX.Tests/TestFqdnCache.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Reflection;
+using Xunit;
+
+namespace EventViewerX.Tests {
+    public class TestFqdnCache {
+        [Fact]
+        public void GetFqdnCachesResult() {
+            if (!OperatingSystem.IsWindows()) return;
+
+            var type = typeof(SearchEvents);
+            var field = type.GetField("_fqdn", BindingFlags.NonPublic | BindingFlags.Static);
+            var method = type.GetMethod("GetFQDN", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(field);
+            Assert.NotNull(method);
+
+            field!.SetValue(null, null);
+            var first = (string)method!.Invoke(null, null)!;
+            Assert.False(string.IsNullOrEmpty(first));
+            Assert.Equal(first, (string)field.GetValue(null)!);
+
+            field.SetValue(null, "cached.example.com");
+            var second = (string)method.Invoke(null, null)!;
+            Assert.Equal("cached.example.com", second);
+            Assert.Equal("cached.example.com", (string)field.GetValue(null)!);
+
+            field.SetValue(null, null);
+        }
+    }
+}

--- a/Sources/EventViewerX/SearchEvents.Fqdn.cs
+++ b/Sources/EventViewerX/SearchEvents.Fqdn.cs
@@ -1,0 +1,24 @@
+namespace EventViewerX;
+
+public partial class SearchEvents : Settings {
+    private static string _fqdn;
+
+    /// <summary>
+    /// Get the fully qualified domain name of the machine
+    /// </summary>
+    /// <returns>Machine FQDN.</returns>
+    private static string GetFQDN() {
+        if (!string.IsNullOrEmpty(_fqdn)) {
+            return _fqdn;
+        }
+
+        try {
+            _fqdn = Dns.GetHostEntry("").HostName;
+        } catch (Exception ex) {
+            _logger.WriteVerbose($"Failed to resolve FQDN via DNS: {ex.Message}. Falling back to machine name.");
+            _fqdn = Environment.MachineName;
+        }
+
+        return _fqdn;
+    }
+}

--- a/Sources/EventViewerX/SearchEvents.QueryLog.cs
+++ b/Sources/EventViewerX/SearchEvents.QueryLog.cs
@@ -45,22 +45,6 @@ public partial class SearchEvents : Settings {
         }
     }
 
-    /// <summary>
-    /// Get the fully qualified domain name of the machine
-    /// </summary>
-    /// <returns>Machine FQDN.</returns>
-    private static string GetFQDN() {
-        try {
-            return Dns.GetHostEntry("").HostName;
-        } catch (Exception ex) {
-            _logger.WriteVerbose($"Failed to resolve FQDN via DNS: {ex.Message}. Falling back to machine name.");
-            return Environment.MachineName;
-        }
-    }
-
-    /// <summary>
-    /// Queries events from a Windows event log file (.evtx) with optional filtering criteria.
-    /// </summary>
     /// <param name="filePath">The file path to the Windows event log file (.evtx) to query.</param>
     /// <param name="eventIds">Optional list of specific event IDs to filter for.</param>
     /// <param name="providerName">Optional name of the event provider to filter by.</param>


### PR DESCRIPTION
## Summary
- store machine FQDN in a static field
- reuse cached FQDN when querying logs
- add unit test covering caching logic

## Testing
- `dotnet build Sources/EventViewerX.sln -c Release` *(fails: NETSDK1045)*
- `dotnet test Sources/EventViewerX.sln -c Release` *(fails: NETSDK1045)*
- `pwsh -NoLogo -NoProfile -Command ./PSEventViewer.Tests.ps1` *(fails: required modules missing)*

------
https://chatgpt.com/codex/tasks/task_e_687019694868832eb93f2fc6e771892b