### PR TITLE
Fix provider filter escaping

### DIFF
--- a/Sources/EventViewerX.Tests/TestBuildQueryString.cs
+++ b/Sources/EventViewerX.Tests/TestBuildQueryString.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Reflection;
+using System.Linq;
+using Xunit;
+
+namespace EventViewerX.Tests {
+    public class TestBuildQueryString {
+        [Fact]
+        public void ProviderNameEscapesSpecialCharacters() {
+            var method = typeof(SearchEvents).GetMethods(BindingFlags.NonPublic | BindingFlags.Static)
+                .First(m => m.Name == "BuildQueryString" && m.GetParameters().Length == 11);
+            string result = (string)method.Invoke(null, new object?[]{"Log", null, "O'Reilly & Co", null, null, null, null, null, null, null, null});
+            Assert.Contains("Provider[@Name='O&apos;Reilly &amp; Co']", result);
+        }
+    }
+}
+

--- a/Sources/EventViewerX.Tests/TestWinEventFilter.cs
+++ b/Sources/EventViewerX.Tests/TestWinEventFilter.cs
@@ -90,5 +90,11 @@ namespace EventViewerX.Tests {
             var result = SearchEvents.BuildWinEventFilter(endTime: end, logName: "x", xpathOnly: true);
             Assert.Contains("timediff(@SystemTime) &gt;= 0", result);
         }
+
+        [Fact]
+        public void ProviderNameEscapesSpecialCharactersWinFilter() {
+            var result = SearchEvents.BuildWinEventFilter(providerName: ["O'Reilly & Co"], logName: "x", xpathOnly: true);
+            Assert.Equal("*[System[Provider[@Name='O&apos;Reilly &amp; Co']]]", result);
+        }
     }
 }

--- a/Sources/EventViewerX/SearchEvents.QueryLog.cs
+++ b/Sources/EventViewerX/SearchEvents.QueryLog.cs
@@ -288,7 +288,8 @@ public partial class SearchEvents : Settings {
 
         // Add provider name to the query
         if (!string.IsNullOrEmpty(providerName)) {
-            AddCondition(queryString, $"Provider[@Name='{providerName}']");
+            var escaped = EscapeXPathValue(providerName);
+            AddCondition(queryString, $"Provider[@Name='{escaped}']");
         }
 
         // Add keywords to the query


### PR DESCRIPTION
## Summary
- escape provider names when building XPath queries
- add tests for provider names with XML-sensitive characters

## Testing
- `dotnet test Sources/EventViewerX.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6870194cbf58832ea3d66cc856f6b688