### PR TITLE
Add advanced examples for filters and watchers

### DIFF
--- a/Examples/Example.NamedDataFilterAdvanced.ps1
+++ b/Examples/Example.NamedDataFilterAdvanced.ps1
@@ -1,0 +1,14 @@
+Import-Module $PSScriptRoot/../PSEventViewer.psd1 -Force
+
+$includeFilter = @{
+    SubjectUserName = 'user1','user2'
+    TargetUserName  = 'server$'
+}
+
+$excludeFilter = @{
+    ProcessName = 'cmd.exe','powershell.exe'
+}
+
+Get-EVXEvent -LogName 'Security' -NamedDataFilter $includeFilter -NamedDataExcludeFilter $excludeFilter -Oldest -MaxEvents 10 |
+    Format-Table TimeCreated, Id, SubjectUserName, TargetUserName, ProcessName
+

--- a/Examples/Example.WatchAdvanced.ps1
+++ b/Examples/Example.WatchAdvanced.ps1
@@ -1,0 +1,13 @@
+Import-Module $PSScriptRoot/../PSEventViewer.psd1 -Force
+
+$action = {
+    param($Event)
+    Write-Host "Advanced watcher saw event $($Event.Id)" -ForegroundColor Cyan
+}
+
+Start-EVXWatcher -Name 'AdvancedWatcher' -MachineName $env:COMPUTERNAME -LogName 'Application' -EventId 1000 -Action $action -Staging -StopOnMatch -TimeOut (New-TimeSpan -Minutes 1)
+
+Start-Sleep -Seconds 65
+
+Get-EVXWatcher -Name 'AdvancedWatcher'
+

--- a/README.md
+++ b/README.md
@@ -105,3 +105,10 @@ The `TimePeriod` enumeration simplifies building date ranges. Each option sets t
 | TillLastSaturday | Since last Saturday |
 | TillLastSunday | Since last Sunday |
 
+### Example scripts
+
+See the `Examples` folder for more scenarios.
+
+- `Example.NamedDataFilterAdvanced.ps1` shows how to combine include and exclude named data filters.
+- `Example.WatchAdvanced.ps1` demonstrates a watcher using staging mode with `-StopOnMatch`.
+


### PR DESCRIPTION
## Summary
- add `Example.NamedDataFilterAdvanced.ps1` demonstrating complex named filters
- add `Example.WatchAdvanced.ps1` showing a watcher using staging and StopOnMatch
- mention the new examples in README

## Testing
- `pwsh -NoLogo -NoProfile -Command ./PSEventViewer.Tests.ps1` *(fails: Invoke-Pester not found)*

------
https://chatgpt.com/codex/tasks/task_e_687020ff54fc832e9d2ba58185988bb4