### PR TITLE
Add reflection caching to DataTableHelper

### DIFF
--- a/Sources/EventViewerX.Examples/Examples.DataTable.cs
+++ b/Sources/EventViewerX.Examples/Examples.DataTable.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Data;
+using System.Linq;
+using EventViewerX.Helpers;
+
+namespace EventViewerX.Examples {
+    internal partial class Examples {
+        public static void DataTableConversion() {
+            var events = SearchEvents.QueryLog("Application", [1000]).Take(5).ToList();
+            DataTable table = events.ToDataTable();
+            Console.WriteLine($"Converted rows: {table.Rows.Count}");
+        }
+    }
+}

--- a/Sources/EventViewerX.Tests/TestDataTableHelper.cs
+++ b/Sources/EventViewerX.Tests/TestDataTableHelper.cs
@@ -20,8 +20,9 @@ public class TestDataTableHelper {
         var cacheField = helperType.GetField("_cache", BindingFlags.NonPublic | BindingFlags.Static);
         Assert.NotNull(cacheField);
 
-        dynamic cache = cacheField!.GetValue(null)!;
-        cache.Clear();
+        object cache = cacheField!.GetValue(null)!;
+        MethodInfo clearMethod = cacheField.FieldType.GetMethod("Clear")!;
+        clearMethod.Invoke(cache, null);
 
         var method = helperType.GetMethod("ToDataTableInternal", BindingFlags.NonPublic | BindingFlags.Static);
         Assert.NotNull(method);
@@ -33,13 +34,15 @@ public class TestDataTableHelper {
 
         generic.Invoke(null, new object[] { items });
 
-        Assert.Equal(1, (int)cache.Count);
-        var first = cache[typeof(SimpleEvent)];
+        PropertyInfo countProperty = cacheField.FieldType.GetProperty("Count")!;
+        Assert.Equal(1, (int)countProperty.GetValue(cache)!);
+        PropertyInfo indexer = cacheField.FieldType.GetProperty("Item")!;
+        var first = indexer.GetValue(cache, new object[] { typeof(SimpleEvent) });
 
         generic.Invoke(null, new object[] { items });
 
-        Assert.Equal(1, (int)cache.Count);
-        var second = cache[typeof(SimpleEvent)];
+        Assert.Equal(1, (int)countProperty.GetValue(cache)!);
+        var second = indexer.GetValue(cache, new object[] { typeof(SimpleEvent) });
 
         Assert.Same(first, second);
     }

--- a/Sources/EventViewerX.Tests/TestDataTableHelper.cs
+++ b/Sources/EventViewerX.Tests/TestDataTableHelper.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Reflection;
+using EventViewerX.Helpers;
+using Xunit;
+
+namespace EventViewerX.Tests;
+
+public class TestDataTableHelper {
+    private class SimpleEvent {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public Dictionary<string, string> Data { get; set; } = new();
+    }
+
+    [Fact]
+    public void CachesTypeMembers() {
+        var helperType = typeof(DataTableHelper);
+        var cacheField = helperType.GetField("_cache", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(cacheField);
+
+        dynamic cache = cacheField!.GetValue(null)!;
+        cache.Clear();
+
+        var method = helperType.GetMethod("ToDataTableInternal", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(method);
+        var generic = method!.MakeGenericMethod(typeof(SimpleEvent));
+
+        var items = new List<SimpleEvent> {
+            new() { Id = 1, Name = "A", Data = new() { { "Key", "Value" } } }
+        };
+
+        generic.Invoke(null, new object[] { items });
+
+        Assert.Equal(1, (int)cache.Count);
+        var first = cache[typeof(SimpleEvent)];
+
+        generic.Invoke(null, new object[] { items });
+
+        Assert.Equal(1, (int)cache.Count);
+        var second = cache[typeof(SimpleEvent)];
+
+        Assert.Same(first, second);
+    }
+}

--- a/Sources/EventViewerX/Helpers/DataTableHelper.cs
+++ b/Sources/EventViewerX/Helpers/DataTableHelper.cs
@@ -1,119 +1,119 @@
 using System;
-using System.Collections.Generic;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Data;
 using System.Linq;
 using System.Reflection;
 
-namespace EventViewerX.Helpers {
-    /// <summary>
-    /// Helper methods for converting collections of events to <see cref="DataTable"/>.
-    /// </summary>
-    public static class DataTableHelper {
-        private sealed class MemberCache {
-            public List<PropertyInfo> Properties { get; }
-            public List<FieldInfo> Fields { get; }
-            public PropertyInfo? DataProperty { get; }
+namespace EventViewerX.Helpers;
 
-            public MemberCache(List<PropertyInfo> properties, List<FieldInfo> fields, PropertyInfo? dataProperty) {
-                Properties = properties;
-                Fields = fields;
-                DataProperty = dataProperty;
+/// <summary>
+/// Helper methods for converting collections of events to <see cref="DataTable"/>.
+/// </summary>
+public static class DataTableHelper {
+    private sealed class MemberCache {
+        public List<PropertyInfo> Properties { get; }
+        public List<FieldInfo> Fields { get; }
+        public PropertyInfo? DataProperty { get; }
+
+        public MemberCache(List<PropertyInfo> properties, List<FieldInfo> fields, PropertyInfo? dataProperty) {
+            Properties = properties;
+            Fields = fields;
+            DataProperty = dataProperty;
+        }
+    }
+
+    private static readonly ConcurrentDictionary<Type, MemberCache> _cache = new();
+    /// <summary>
+    /// Converts a collection of <see cref="EventObject"/> instances to a <see cref="DataTable"/>.
+    /// </summary>
+    /// <param name="events">Events to convert.</param>
+    /// <returns>DataTable containing event data.</returns>
+    public static DataTable ToDataTable(this IEnumerable<EventObject> events) {
+        return ToDataTableInternal(events);
+    }
+
+    /// <summary>
+    /// Converts a collection of <see cref="EventObjectSlim"/> instances to a <see cref="DataTable"/>.
+    /// </summary>
+    /// <param name="events">Events to convert.</param>
+    /// <returns>DataTable containing event data.</returns>
+    public static DataTable ToDataTable(this IEnumerable<EventObjectSlim> events) {
+        return ToDataTableInternal(events);
+    }
+
+    private static DataTable ToDataTableInternal<T>(IEnumerable<T> items) where T : class {
+        if (items == null) throw new ArgumentNullException(nameof(items));
+        var list = items.ToList();
+        var dataTable = new DataTable(typeof(T).Name);
+        if (!list.Any()) return dataTable;
+
+        var cache = _cache.GetOrAdd(
+            typeof(T),
+            static type => new MemberCache(
+                type.GetProperties(BindingFlags.Instance | BindingFlags.Public)
+                    .Where(p => IsSimpleType(p.PropertyType)).ToList(),
+                type.GetFields(BindingFlags.Instance | BindingFlags.Public)
+                    .Where(f => IsSimpleType(f.FieldType)).ToList(),
+                type.GetProperty("Data", BindingFlags.Instance | BindingFlags.Public)
+            ));
+
+        var properties = cache.Properties;
+        var fields = cache.Fields;
+        var dataProperty = cache.DataProperty;
+
+        foreach (var prop in properties) {
+            var type = Nullable.GetUnderlyingType(prop.PropertyType) ?? prop.PropertyType;
+            dataTable.Columns.Add(prop.Name, type);
+        }
+        foreach (var field in fields) {
+            var type = Nullable.GetUnderlyingType(field.FieldType) ?? field.FieldType;
+            if (!dataTable.Columns.Contains(field.Name)) {
+                dataTable.Columns.Add(field.Name, type);
             }
         }
 
-        private static readonly ConcurrentDictionary<Type, MemberCache> _cache = new();
-        /// <summary>
-        /// Converts a collection of <see cref="EventObject"/> instances to a <see cref="DataTable"/>.
-        /// </summary>
-        /// <param name="events">Events to convert.</param>
-        /// <returns>DataTable containing event data.</returns>
-        public static DataTable ToDataTable(this IEnumerable<EventObject> events) {
-            return ToDataTableInternal(events);
+        HashSet<string> dataKeys = new();
+        if (dataProperty != null && dataProperty.PropertyType == typeof(Dictionary<string, string>)) {
+            foreach (var item in list) {
+                if (dataProperty.GetValue(item) is Dictionary<string, string> dict) {
+                    foreach (var key in dict.Keys) {
+                        dataKeys.Add(key);
+                    }
+                }
+            }
+            foreach (var key in dataKeys) {
+                if (!dataTable.Columns.Contains(key)) {
+                    dataTable.Columns.Add(key, typeof(string));
+                }
+            }
         }
 
-        /// <summary>
-        /// Converts a collection of <see cref="EventObjectSlim"/> instances to a <see cref="DataTable"/>.
-        /// </summary>
-        /// <param name="events">Events to convert.</param>
-        /// <returns>DataTable containing event data.</returns>
-        public static DataTable ToDataTable(this IEnumerable<EventObjectSlim> events) {
-            return ToDataTableInternal(events);
-        }
-
-        private static DataTable ToDataTableInternal<T>(IEnumerable<T> items) where T : class {
-            if (items == null) throw new ArgumentNullException(nameof(items));
-            var list = items.ToList();
-            var dataTable = new DataTable(typeof(T).Name);
-            if (!list.Any()) return dataTable;
-
-            var cache = _cache.GetOrAdd(
-                typeof(T),
-                static type => new MemberCache(
-                    type.GetProperties(BindingFlags.Instance | BindingFlags.Public)
-                        .Where(p => IsSimpleType(p.PropertyType)).ToList(),
-                    type.GetFields(BindingFlags.Instance | BindingFlags.Public)
-                        .Where(f => IsSimpleType(f.FieldType)).ToList(),
-                    type.GetProperty("Data", BindingFlags.Instance | BindingFlags.Public)
-                ));
-
-            var properties = cache.Properties;
-            var fields = cache.Fields;
-            var dataProperty = cache.DataProperty;
-
+        foreach (var item in list) {
+            var row = dataTable.NewRow();
             foreach (var prop in properties) {
-                var type = Nullable.GetUnderlyingType(prop.PropertyType) ?? prop.PropertyType;
-                dataTable.Columns.Add(prop.Name, type);
+                row[prop.Name] = prop.GetValue(item) ?? DBNull.Value;
             }
             foreach (var field in fields) {
-                var type = Nullable.GetUnderlyingType(field.FieldType) ?? field.FieldType;
-                if (!dataTable.Columns.Contains(field.Name)) {
-                    dataTable.Columns.Add(field.Name, type);
-                }
+                row[field.Name] = field.GetValue(item) ?? DBNull.Value;
             }
-
-            HashSet<string> dataKeys = new();
-            if (dataProperty != null && dataProperty.PropertyType == typeof(Dictionary<string, string>)) {
-                foreach (var item in list) {
-                    if (dataProperty.GetValue(item) is Dictionary<string, string> dict) {
-                        foreach (var key in dict.Keys) {
-                            dataKeys.Add(key);
-                        }
-                    }
-                }
+            if (dataProperty != null && dataProperty.GetValue(item) is Dictionary<string, string> dict) {
                 foreach (var key in dataKeys) {
-                    if (!dataTable.Columns.Contains(key)) {
-                        dataTable.Columns.Add(key, typeof(string));
+                    if (dict.TryGetValue(key, out var value) && value != null) {
+                        row[key] = value;
+                    } else {
+                        row[key] = DBNull.Value;
                     }
                 }
             }
-
-            foreach (var item in list) {
-                var row = dataTable.NewRow();
-                foreach (var prop in properties) {
-                    row[prop.Name] = prop.GetValue(item) ?? DBNull.Value;
-                }
-                foreach (var field in fields) {
-                    row[field.Name] = field.GetValue(item) ?? DBNull.Value;
-                }
-                if (dataProperty != null && dataProperty.GetValue(item) is Dictionary<string, string> dict) {
-                    foreach (var key in dataKeys) {
-                        if (dict.TryGetValue(key, out var value) && value != null) {
-                            row[key] = value;
-                        } else {
-                            row[key] = DBNull.Value;
-                        }
-                    }
-                }
-                dataTable.Rows.Add(row);
-            }
-
-            return dataTable;
+            dataTable.Rows.Add(row);
         }
 
-        private static bool IsSimpleType(Type type) {
-            type = Nullable.GetUnderlyingType(type) ?? type;
-            return type.IsPrimitive || type.IsEnum || type == typeof(string) || type == typeof(DateTime) || type == typeof(decimal) || type == typeof(Guid);
-        }
+        return dataTable;
+    }
+
+    private static bool IsSimpleType(Type type) {
+        type = Nullable.GetUnderlyingType(type) ?? type;
+        return type.IsPrimitive || type.IsEnum || type == typeof(string) || type == typeof(DateTime) || type == typeof(decimal) || type == typeof(Guid);
     }
 }


### PR DESCRIPTION
## Summary
- cache type metadata using ConcurrentDictionary
- add example showing DataTable conversion
- unit test verifies caching behavior

## Testing
- `dotnet test Sources/EventViewerX.Tests/EventViewerX.Tests.csproj` *(fails: NETSDK1045)*

------
https://chatgpt.com/codex/tasks/task_e_687020f403b0832e97ba54dfbfaa88dc