### PR TITLE
Handle empty machine name

### DIFF
--- a/Sources/EventViewerX.Tests/TestMachineNameEdgeCases.cs
+++ b/Sources/EventViewerX.Tests/TestMachineNameEdgeCases.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace EventViewerX.Tests {
+    public class TestMachineNameEdgeCases {
+        [Fact]
+        public void QueryLogHandlesEmptyMachineName() {
+            if (!OperatingSystem.IsWindows()) return;
+            using var enumerator = SearchEvents.QueryLog(KnownLog.Setup, null, string.Empty).GetEnumerator();
+            if (enumerator.MoveNext()) {
+                Assert.NotNull(enumerator.Current);
+            }
+        }
+
+        [Fact]
+        public void WatchHandlesNullMachineName() {
+            if (!OperatingSystem.IsWindows()) return;
+            var watcher = new WatchEvents();
+            watcher.Watch(null, "Application", new List<int> { 1 });
+            watcher.Dispose();
+        }
+    }
+}

--- a/Sources/EventViewerX/SearchEvents.LogDetails.cs
+++ b/Sources/EventViewerX/SearchEvents.LogDetails.cs
@@ -10,7 +10,7 @@ public partial class SearchEvents : Settings {
 
     public static IEnumerable<EventLogDetails> DisplayEventLogs(string[] listLog = null, string machineName = null) {
         EventLogSession session;
-        if (machineName != null) {
+        if (!string.IsNullOrEmpty(machineName)) {
             session = new EventLogSession(machineName);
         } else {
             session = new EventLogSession();

--- a/Sources/EventViewerX/SearchEvents.QueryLog.cs
+++ b/Sources/EventViewerX/SearchEvents.QueryLog.cs
@@ -26,21 +26,22 @@ public partial class SearchEvents : Settings {
     /// <param name="machineName">Name of the machine.</param>
     /// <returns>Initialized <see cref="EventLogReader"/> or null when failed.</returns>
     private static EventLogReader CreateEventLogReader(EventLogQuery query, string machineName) {
+        string targetMachine = string.IsNullOrEmpty(machineName) ? GetFQDN() : machineName;
         if (query == null) {
-            _logger.WriteWarning($"An error occurred on {machineName} while creating the event log reader: Query cannot be null.");
+            _logger.WriteWarning($"An error occurred on {targetMachine} while creating the event log reader: Query cannot be null.");
             return null;
         }
 
         try {
             return new EventLogReader(query);
         } catch (EventLogException ex) {
-            _logger.WriteWarning($"An error occurred on {machineName} while creating the event log reader: {ex.Message}");
+            _logger.WriteWarning($"An error occurred on {targetMachine} while creating the event log reader: {ex.Message}");
             return null;
         } catch (UnauthorizedAccessException ex) {
-            _logger.WriteWarning($"Insufficient permissions to read the event log on {machineName}: {ex.Message}");
+            _logger.WriteWarning($"Insufficient permissions to read the event log on {targetMachine}: {ex.Message}");
             return null;
         } catch (Exception ex) {
-            _logger.WriteWarning($"An error occurred on {machineName} while creating the event log reader: {ex.Message}");
+            _logger.WriteWarning($"An error occurred on {targetMachine} while creating the event log reader: {ex.Message}");
             return null;
         }
     }
@@ -171,11 +172,11 @@ public partial class SearchEvents : Settings {
         _logger.WriteVerbose($"Querying log '{logName}' on '{machineName} with query: {queryString}");
 
         EventLogQuery query = new EventLogQuery(logName, PathType.LogName, queryString);
-        if (machineName != null) {
+        if (!string.IsNullOrEmpty(machineName)) {
             query.Session = new EventLogSession(machineName);
         }
 
-        var queriedMachine = machineName ?? GetFQDN();
+        var queriedMachine = string.IsNullOrEmpty(machineName) ? GetFQDN() : machineName;
 
         EventRecord record;
         using (EventLogReader reader = CreateEventLogReader(query, machineName)) {

--- a/Sources/EventViewerX/WatchEvents.cs
+++ b/Sources/EventViewerX/WatchEvents.cs
@@ -72,7 +72,7 @@ namespace EventViewerX {
             _eventsFound = 0;
             StartTime = DateTime.UtcNow;
             Dispose();
-            _machineName = machineName;
+            _machineName = string.IsNullOrEmpty(machineName) ? Environment.MachineName : machineName;
             if (staging && !eventId.Contains(350)) {
                 eventId.Add(350);
                 StagingEnabled = true;
@@ -84,10 +84,14 @@ namespace EventViewerX {
             _watchEventId = new ConcurrentBag<int>(eventId);
             _eventAction = eventAction;
             try {
-                _eventLogSession = new EventLogSession(machineName);
-                _eventLogWatcher = new EventLogWatcher(new EventLogQuery(logName, PathType.LogName) {
-                    Session = _eventLogSession
-                });
+                if (!string.IsNullOrEmpty(machineName)) {
+                    _eventLogSession = new EventLogSession(machineName);
+                }
+                EventLogQuery query = new EventLogQuery(logName, PathType.LogName);
+                if (_eventLogSession != null) {
+                    query.Session = _eventLogSession;
+                }
+                _eventLogWatcher = new EventLogWatcher(query);
                 _eventLogWatcher.EventRecordWritten += DetectEventsLogCallback;
                 _eventLogWatcher.Enabled = true;
                 cancellationToken.Register(() => Dispose());


### PR DESCRIPTION
## Summary
- handle empty machine name when creating `EventLogSession`
- ensure error messages mention the actual machine queried
- update watcher to only create `EventLogSession` when needed
- add regression tests for empty machine name cases

## Testing
- `dotnet build Sources/EventViewerX.sln -p:TargetFrameworks=net8.0`
- `dotnet test Sources/EventViewerX.sln -p:TargetFrameworks=net8.0` *(fails: No test is available)*
- `pwsh -NoProfile -NonInteractive -File ./PSEventViewer.Tests.ps1` *(fails: required modules missing)*

------
https://chatgpt.com/codex/tasks/task_e_68702109f2fc832e9567859bb12d308c