### PR TITLE
Add network monitor related named events

### DIFF
--- a/Sources/EventViewerX.Examples/Examples.NetworkMonitor.cs
+++ b/Sources/EventViewerX.Examples/Examples.NetworkMonitor.cs
@@ -1,3 +1,5 @@
+using EventViewerX.Rules.Windows;
+
 namespace EventViewerX.Examples {
     internal partial class Examples {
         public static async Task FindNetworkMonitorEvents() {
@@ -5,7 +7,13 @@ namespace EventViewerX.Examples {
                 NamedEvents.NetworkMonitorDriverLoaded,
                 NamedEvents.NetworkPromiscuousMode
             ])) {
-                Console.WriteLine($"Event: {evt.Type} {evt.EventID} on {evt.ComputerName}");
+                var computer = evt switch {
+                    NetworkMonitorDriverLoaded driver => driver.Computer,
+                    NetworkPromiscuousMode promiscuous => promiscuous.Computer,
+                    _ => evt.GatheredFrom
+                };
+
+                Console.WriteLine($"Event: {evt.Type} {evt.EventID} on {computer}");
             }
         }
     }

--- a/Sources/EventViewerX.Examples/Examples.NetworkMonitor.cs
+++ b/Sources/EventViewerX.Examples/Examples.NetworkMonitor.cs
@@ -1,0 +1,12 @@
+namespace EventViewerX.Examples {
+    internal partial class Examples {
+        public static async Task FindNetworkMonitorEvents() {
+            await foreach (var evt in SearchEvents.FindEventsByNamedEvents([
+                NamedEvents.NetworkMonitorDriverLoaded,
+                NamedEvents.NetworkPromiscuousMode
+            ])) {
+                Console.WriteLine($"Event: {evt.Type} {evt.EventID} on {evt.ComputerName}");
+            }
+        }
+    }
+}

--- a/Sources/EventViewerX.Tests/TestNetworkMonitorEvents.cs
+++ b/Sources/EventViewerX.Tests/TestNetworkMonitorEvents.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using Xunit;
+
+namespace EventViewerX.Tests {
+    public class TestNetworkMonitorEvents {
+        [Fact]
+        public void EventInfoContainsNetworkMonitorEvents() {
+            var info = EventObjectSlim.GetEventInfoForNamedEvents(new List<NamedEvents> {
+                NamedEvents.NetworkMonitorDriverLoaded,
+                NamedEvents.NetworkPromiscuousMode
+            });
+
+            Assert.Contains(6, info["System"]);
+            Assert.Contains(7035, info["System"]);
+            Assert.Contains(7045, info["System"]);
+            Assert.Contains(10400, info["System"]);
+            Assert.Contains(10401, info["System"]);
+        }
+    }
+}

--- a/Sources/EventViewerX/Enums/NamedEvents.cs
+++ b/Sources/EventViewerX/Enums/NamedEvents.cs
@@ -371,5 +371,15 @@
         /// Azure AD Connect run profile completed
         /// </summary>
         AADConnectRunProfile,
+
+        /// <summary>
+        /// Network monitor driver loaded (events 6, 7035, 7045)
+        /// </summary>
+        NetworkMonitorDriverLoaded,
+
+        /// <summary>
+        /// Network adapter entered promiscuous mode (events 10400, 10401)
+        /// </summary>
+        NetworkPromiscuousMode,
     }
 }

--- a/Sources/EventViewerX/Rules/Windows/NetworkMonitorDriverLoaded.cs
+++ b/Sources/EventViewerX/Rules/Windows/NetworkMonitorDriverLoaded.cs
@@ -1,0 +1,43 @@
+namespace EventViewerX.Rules.Windows;
+
+/// <summary>
+/// Network monitor driver loaded
+/// 6: Filter Manager driver loaded
+/// </summary>
+public class NetworkMonitorDriverLoaded : EventRuleBase {
+    public override List<int> EventIds => new() { 6, 7035, 7045 };
+    public override string LogName => "System";
+    public override NamedEvents NamedEvent => NamedEvents.NetworkMonitorDriverLoaded;
+
+    private static readonly string[] _driverNames = ["npcap", "npf", "netmon"];
+
+    public override bool CanHandle(EventObject eventObject) {
+        if (eventObject.ProviderName.Equals("Service Control Manager", StringComparison.OrdinalIgnoreCase) &&
+            (eventObject.Id == 7035 || eventObject.Id == 7045)) {
+            var msg = eventObject.MessageSubject ?? string.Empty;
+            return _driverNames.Any(name => msg.IndexOf(name, StringComparison.OrdinalIgnoreCase) >= 0);
+        }
+
+        if (eventObject.ProviderName.Equals("Microsoft-Windows-FilterManager", StringComparison.OrdinalIgnoreCase) &&
+            eventObject.Id == 6) {
+            var drv = eventObject.GetValueFromDataDictionary("DriverName", "FilterName", "ImageName") ?? string.Empty;
+            return _driverNames.Any(name => drv.IndexOf(name, StringComparison.OrdinalIgnoreCase) >= 0);
+        }
+
+        return false;
+    }
+
+    public string Computer;
+    public string DriverName;
+    public DateTime When;
+
+    public NetworkMonitorDriverLoaded(EventObject eventObject) : base(eventObject) {
+        _eventObject = eventObject;
+        Type = "NetworkMonitorDriverLoaded";
+        Computer = _eventObject.ComputerName;
+        DriverName = _eventObject.GetValueFromDataDictionary("DriverName", "FilterName", "ImageName") ??
+                     _driverNames.FirstOrDefault(n => (_eventObject.MessageSubject ?? string.Empty)
+                         .IndexOf(n, StringComparison.OrdinalIgnoreCase) >= 0) ?? string.Empty;
+        When = _eventObject.TimeCreated;
+    }
+}

--- a/Sources/EventViewerX/Rules/Windows/NetworkPromiscuousMode.cs
+++ b/Sources/EventViewerX/Rules/Windows/NetworkPromiscuousMode.cs
@@ -1,0 +1,28 @@
+namespace EventViewerX.Rules.Windows;
+
+/// <summary>
+/// Network adapter entered promiscuous mode
+/// 104: NDIS indicates adapter promiscuous mode
+/// </summary>
+public class NetworkPromiscuousMode : EventRuleBase {
+    public override List<int> EventIds => new() { 10400, 10401 };
+    public override string LogName => "System";
+    public override NamedEvents NamedEvent => NamedEvents.NetworkPromiscuousMode;
+
+    public override bool CanHandle(EventObject eventObject) {
+        return eventObject.ProviderName.Equals("Ndis", StringComparison.OrdinalIgnoreCase) &&
+               (eventObject.Id == 10400 || eventObject.Id == 10401);
+    }
+
+    public string Computer;
+    public string Adapter;
+    public DateTime When;
+
+    public NetworkPromiscuousMode(EventObject eventObject) : base(eventObject) {
+        _eventObject = eventObject;
+        Type = "NetworkPromiscuousMode";
+        Computer = _eventObject.ComputerName;
+        Adapter = _eventObject.GetValueFromDataDictionary("AdapterName", "Name");
+        When = _eventObject.TimeCreated;
+    }
+}


### PR DESCRIPTION
## Summary
- add `NetworkMonitorDriverLoaded` and `NetworkPromiscuousMode` named events
- implement rule classes for targeted network monitor driver load and promiscuous mode detection
- provide example showing how to query the new events
- cover the new events with unit tests
- clarify enum summaries with specific event IDs

## Testing
- `dotnet build Sources/EventViewerX/EventViewerX.csproj -c Release -p:TargetFramework=net8.0 -p:TargetFrameworks=net8.0`
- `dotnet test Sources/EventViewerX.Tests/EventViewerX.Tests.csproj -c Release -p:TargetFramework=net8.0 -p:TargetFrameworks=net8.0`
- `pwsh -NoLogo -NoProfile -File PSEventViewer.Tests.ps1` *(fails: Write-Color not found)*

------
https://chatgpt.com/codex/tasks/task_e_68709bdc2174832ebeba88a6b61752d1