### PR TITLE
Fix DataTableHelper return value

### DIFF
--- a/Sources/EventViewerX.Tests/TestDataTableHelper.cs
+++ b/Sources/EventViewerX.Tests/TestDataTableHelper.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace EventViewerX.Tests;
 
-public class TestDataTableHelper {
+public partial class TestDataTableHelper {
     private class SimpleEvent {
         public int Id { get; set; }
         public string Name { get; set; }
@@ -46,9 +46,9 @@ public class TestDataTableHelper {
 
         Assert.Same(first, second);
     }
+}
 
-    [Fact]
-    public class TestDataTableHelper {
+public partial class TestDataTableHelper {
         private class Dummy {
             public int? IntValue { get; set; }
             public DateTime? DateValue { get; set; }
@@ -85,4 +85,3 @@ public class TestDataTableHelper {
             Assert.Equal(DBNull.Value, table.Rows[1]["DoubleValue"]);
         }
     }
-}

--- a/Sources/EventViewerX/Helpers/DataTableHelper.cs
+++ b/Sources/EventViewerX/Helpers/DataTableHelper.cs
@@ -109,6 +109,7 @@ public static class DataTableHelper {
             dataTable.Rows.Add(row);
         }
 
+        return dataTable;
     }
   
     private static bool IsSimpleType(Type type) {


### PR DESCRIPTION
## Summary
- ensure DataTableHelper.ToDataTableInternal returns created table
- correct TestDataTableHelper definitions so project builds

## Testing
- `dotnet test Sources/EventViewerX.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6872bdaf7938832e95136280f75c4edd