### PR TITLE
Add AuthenticationType enum for NPS rule

### DIFF
--- a/Sources/EventViewerX.Tests/TestNetworkAccessAuthenticationPolicy.cs
+++ b/Sources/EventViewerX.Tests/TestNetworkAccessAuthenticationPolicy.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Xunit;
+using EventViewerX;
+
+namespace EventViewerX.Tests {
+    public class TestNetworkAccessAuthenticationPolicy {
+        private static Dictionary<string, string> Parse(string xml) {
+            var obj = (EventObject)System.Runtime.Serialization.FormatterServices.GetUninitializedObject(typeof(EventObject));
+            var method = typeof(EventObject).GetMethod("ParseXML", BindingFlags.NonPublic | BindingFlags.Instance)!
+                .MakeGenericMethod(typeof(Dictionary<string, string>));
+            return (Dictionary<string, string>)method.Invoke(obj, new object[] { xml })!;
+        }
+
+        [Fact]
+        public void ParsesKnownAuthenticationType() {
+            const string xml = "<Event><EventData><Data Name='AuthenticationType'>PAP</Data></EventData></Event>";
+            var data = Parse(xml);
+            var result = Rules.NPS.NetworkAccessAuthenticationPolicy.ParseAuthenticationType(data["AuthenticationType"]);
+            Assert.Equal(AuthenticationType.PAP, result);
+        }
+
+        [Fact]
+        public void UnknownAuthenticationTypeDefaultsToUnknown() {
+            const string xml = "<Event><EventData><Data Name='AuthenticationType'>UNKNOWN_VALUE</Data></EventData></Event>";
+            var data = Parse(xml);
+            var result = Rules.NPS.NetworkAccessAuthenticationPolicy.ParseAuthenticationType(data["AuthenticationType"]);
+            Assert.Equal(AuthenticationType.Unknown, result);
+        }
+    }
+}

--- a/Sources/EventViewerX/Enums/AuthenticationType.cs
+++ b/Sources/EventViewerX/Enums/AuthenticationType.cs
@@ -1,0 +1,24 @@
+namespace EventViewerX;
+
+/// <summary>
+/// Typical RADIUS authentication types.
+/// </summary>
+public enum AuthenticationType {
+    /// <summary>Authentication type is not recognized.</summary>
+    Unknown,
+
+    /// <summary>PAP or clear text authentication.</summary>
+    PAP,
+
+    /// <summary>Challenge Handshake Authentication Protocol.</summary>
+    CHAP,
+
+    /// <summary>Microsoft CHAP.</summary>
+    MSCHAP,
+
+    /// <summary>Microsoft CHAP version 2.</summary>
+    MSCHAPv2,
+
+    /// <summary>Extensible Authentication Protocol.</summary>
+    EAP
+}

--- a/Sources/EventViewerX/Rules/NPS/NetworkAccessAuthenticationPolicy.cs
+++ b/Sources/EventViewerX/Rules/NPS/NetworkAccessAuthenticationPolicy.cs
@@ -107,7 +107,11 @@ public class NetworkAccessAuthenticationPolicy : EventRuleBase {
     /// <summary>
     /// Authentication type selected.
     /// </summary>
-    public string AuthenticationType;
+    public AuthenticationType AuthenticationType;
+
+    internal static AuthenticationType ParseAuthenticationType(string value) {
+        return Enum.TryParse<AuthenticationType>(value, true, out var parsed) ? parsed : AuthenticationType.Unknown;
+    }
 
     /// <summary>
     /// EAP type value if applicable.
@@ -157,7 +161,8 @@ public class NetworkAccessAuthenticationPolicy : EventRuleBase {
 
         AuthenticationProvider = _eventObject.GetValueFromDataDictionary("AuthenticationProvider");
         AuthenticationServer = _eventObject.GetValueFromDataDictionary("AuthenticationServer");
-        AuthenticationType = _eventObject.GetValueFromDataDictionary("AuthenticationType");
+        var authType = _eventObject.GetValueFromDataDictionary("AuthenticationType");
+        AuthenticationType = ParseAuthenticationType(authType);
 
         EAPType = _eventObject.GetValueFromDataDictionary("EAPType");
 


### PR DESCRIPTION
## Summary
- implement `AuthenticationType` enum with typical RADIUS values
- parse the new enum inside `NetworkAccessAuthenticationPolicy`
- add unit tests covering authentication type parsing

## Testing
- `dotnet test Sources/EventViewerX.Tests/EventViewerX.Tests.csproj -c Release -p:TargetFrameworks=net8.0` *(fails: No test is available)*

------
https://chatgpt.com/codex/tasks/task_e_687caba2ccec832eb85d822a944b73d6