### PR TITLE
Add NasPortType enum and integrate parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,16 @@ The `TimePeriod` enumeration simplifies building date ranges. Each option sets t
 | TillLastSaturday | Since last Saturday |
 | TillLastSunday | Since last Sunday |
 
+### NasPortType values
+
+The `NasPortType` enumeration maps common RADIUS NAS-Port-Type values.
+
+| Value | Description |
+|-------|-------------|
+| Ethernet | IEEE 802.3 Ethernet |
+| WirelessIEEE80211 | Wireless IEEE 802.11 |
+| Virtual | Virtual port |
+
 ### Example scripts
 
 See the `Examples` folder for more scenarios.

--- a/Sources/EventViewerX.Tests/TestNasPortType.cs
+++ b/Sources/EventViewerX.Tests/TestNasPortType.cs
@@ -1,0 +1,17 @@
+using Xunit;
+
+namespace EventViewerX.Tests;
+
+public class TestNasPortType {
+    [Fact]
+    public void ParseNumericValue() {
+        var result = EventsHelper.GetNasPortType("15");
+        Assert.Equal(NasPortType.Ethernet, result);
+    }
+
+    [Fact]
+    public void ParseStringValue() {
+        var result = EventsHelper.GetNasPortType("WirelessIEEE80211");
+        Assert.Equal(NasPortType.WirelessIEEE80211, result);
+    }
+}

--- a/Sources/EventViewerX/Definitions/NasPortType.cs
+++ b/Sources/EventViewerX/Definitions/NasPortType.cs
@@ -1,0 +1,35 @@
+namespace EventViewerX;
+
+/// <summary>
+/// Identifies the type of network access server port from the RADIUS NAS-Port-Type attribute.
+/// </summary>
+public enum NasPortType {
+    Async = 0,
+    Sync = 1,
+    ISDN = 2,
+    ISDNV120 = 3,
+    ISDNV110 = 4,
+    Virtual = 5,
+    PIAFS = 6,
+    HdlcClearChannel = 7,
+    X25 = 8,
+    X75 = 9,
+    G3Fax = 10,
+    SDSL = 11,
+    ADSLCAP = 12,
+    ADSLDMT = 13,
+    IDSL = 14,
+    Ethernet = 15,
+    XDSL = 16,
+    Cable = 17,
+    WirelessOther = 18,
+    WirelessIEEE80211 = 19,
+    TokenRing = 20,
+    FDDI = 21,
+    WirelessCDMA = 22,
+    WirelessCDPD = 23,
+    WirelessIDEN = 24,
+    Wireless1XEV = 25,
+    IAPP = 26,
+    FTTP = 27
+}

--- a/Sources/EventViewerX/EventsHelper.cs
+++ b/Sources/EventViewerX/EventsHelper.cs
@@ -146,6 +146,36 @@ internal static class EventsHelper {
     }
 
     /// <summary>
+    /// Translates a string value to a NasPortType enum.
+    /// </summary>
+    /// <param name="value">The value to translate.</param>
+    /// <returns>The translated NasPortType enum.</returns>
+    public static NasPortType? GetNasPortType(string value) {
+        if (string.IsNullOrEmpty(value)) {
+            return null;
+        }
+
+        if (value.StartsWith("%%")) {
+            value = value.Trim('%');
+        }
+
+        if (int.TryParse(value, out var number)
+            && Enum.IsDefined(typeof(NasPortType), number)) {
+            return (NasPortType)number;
+        }
+
+        var normalized = value.Replace("-", string.Empty)
+            .Replace(" ", string.Empty)
+            .Replace(".", string.Empty);
+
+        if (Enum.TryParse(normalized, true, out NasPortType result)) {
+            return result;
+        }
+
+        return null;
+    }
+
+    /// <summary>
     /// Translates device class name into a simplified device type.
     /// </summary>
     /// <param name="className">Device class name.</param>

--- a/Sources/EventViewerX/Rules/NPS/NetworkAccessAuthenticationPolicy.cs
+++ b/Sources/EventViewerX/Rules/NPS/NetworkAccessAuthenticationPolicy.cs
@@ -65,9 +65,9 @@ public class NetworkAccessAuthenticationPolicy : EventRuleBase {
     public string NASIdentifier;
 
     /// <summary>
-    /// Type of the NAS port.
+    /// Type of the network access server port.
     /// </summary>
-    public string NASPortType;
+    public NasPortType? NASPortType;
 
     /// <summary>
     /// NAS port number.
@@ -152,7 +152,8 @@ public class NetworkAccessAuthenticationPolicy : EventRuleBase {
 
         NASIdentifier = _eventObject.GetValueFromDataDictionary("NASIdentifier");
         NASPort = _eventObject.GetValueFromDataDictionary("NASPort");
-        NASPortType = _eventObject.GetValueFromDataDictionary("NASPortType");
+        NASPortType = EventsHelper.GetNasPortType(
+            _eventObject.GetValueFromDataDictionary("NASPortType"));
 
 
         AuthenticationProvider = _eventObject.GetValueFromDataDictionary("AuthenticationProvider");


### PR DESCRIPTION
## Summary
- add `NasPortType` enum for NAS port values
- parse NASPortType field into the new enum
- expose parser helper in `EventsHelper`
- document available NAS port types in README
- cover enum parsing with new unit tests

## Testing
- `dotnet test Sources/EventViewerX.sln`
- `pwsh -NoLogo -NoProfile -Command ./PSEventViewer.Tests.ps1` *(fails: Write-Color not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_687cab9649c4832eb0739feb7f6c065e