### PR TITLE
Fix multiple event ID filtering

### DIFF
--- a/Sources/EventViewerX.Tests/TestBuildQueryString.cs
+++ b/Sources/EventViewerX.Tests/TestBuildQueryString.cs
@@ -12,6 +12,14 @@ namespace EventViewerX.Tests {
             string result = (string)method.Invoke(null, new object?[]{"Log", null, "O'Reilly & Co", null, null, null, null, null, null, null, null});
             Assert.Contains("Provider[@Name='O&apos;Reilly &amp; Co']", result);
         }
+
+        [Fact]
+        public void EventIdMultipleValuesOr() {
+            var method = typeof(SearchEvents).GetMethods(BindingFlags.NonPublic | BindingFlags.Static)
+                .First(m => m.Name == "BuildQueryString" && m.GetParameters().Length == 11);
+            string result = (string)method.Invoke(null, new object?[]{"Log", new System.Collections.Generic.List<int>{1, 2}, null, null, null, null, null, null, null, null, null});
+            Assert.Contains("(EventID=1) or (EventID=2)", result);
+        }
     }
 }
 

--- a/Sources/EventViewerX/SearchEvents.QueryLog.cs
+++ b/Sources/EventViewerX/SearchEvents.QueryLog.cs
@@ -169,9 +169,10 @@ public partial class SearchEvents : Settings {
 
         // Add event IDs to the query
         if (eventIds != null) {
-            var validIds = eventIds.Where(id => id > 0).ToList();
+            var validIds = eventIds.Where(id => id > 0).Distinct().ToList();
             if (validIds.Any()) {
-                AddCondition(queryString, "(" + string.Join(" or ", validIds.Select(id => $"EventID={id}")) + ")");
+                var idConditions = validIds.Select(id => $"(EventID={id})");
+                AddCondition(queryString, $"({string.Join(" or ", idConditions)})");
             }
         }
 


### PR DESCRIPTION
## Summary
- ensure BuildQueryString handles multiple IDs correctly
- add test covering multiple EventId values

## Testing
- `dotnet test Sources/EventViewerX.Tests/EventViewerX.Tests.csproj -v minimal`
- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File ./PSEventViewer.Tests.ps1` *(fails: Write-Color not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_687f5fb5b474832ebc393f6e2f9eb8c5