### PR TITLE
Fix provider metadata disposal issue

### DIFF
--- a/Sources/EventViewerX.Tests/TestGetProviders.cs
+++ b/Sources/EventViewerX.Tests/TestGetProviders.cs
@@ -1,0 +1,27 @@
+using System.Linq;
+using Xunit;
+
+namespace EventViewerX.Tests;
+
+public class TestGetProviders
+{
+    [Fact]
+    public void ProvidersMetadataEnumerates()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var provider = SearchEvents.GetProviders().FirstOrDefault();
+        Assert.NotNull(provider);
+        Assert.NotNull(provider!.ProviderName);
+        Assert.NotNull(provider.Events);
+
+        foreach (var evt in provider.Events)
+        {
+            Assert.NotNull(evt);
+            break;
+        }
+    }
+}

--- a/Sources/EventViewerX/SearchEvents.GetPublisher.cs
+++ b/Sources/EventViewerX/SearchEvents.GetPublisher.cs
@@ -20,11 +20,11 @@ namespace EventViewerX {
         /// </summary>
         /// <returns>Enumeration of provider metadata.</returns>
         public static IEnumerable<Metadata> GetProviders() {
-            EventLogSession session = new EventLogSession();
+            using EventLogSession session = new();
             foreach (string providerName in session.GetProviderNames()) {
                 if (!_providerMetadataCache.TryGetValue(providerName, out var metadata)) {
                     try {
-                        using ProviderMetadata providerMetadata = new ProviderMetadata(providerName);
+                        using ProviderMetadata providerMetadata = new(providerName, session);
                         metadata = new Metadata(providerName, providerMetadata);
                         _providerMetadataCache[providerName] = metadata;
                     } catch (EventLogInvalidDataException ex) {
@@ -83,16 +83,16 @@ namespace EventViewerX {
             ProviderName = providerName;
             Id = providerMetadata.Id;
             MessageFilePath = providerMetadata.MessageFilePath;
-            Keywords = providerMetadata.Keywords;
+            Keywords = providerMetadata.Keywords?.ToList();
 
             TrySetMetadata(() => DisplayName = providerMetadata.DisplayName, "display name", providerName);
-            TrySetMetadata(() => LogLinks = providerMetadata.LogLinks, "log links", providerName);
-            TrySetMetadata(() => LogNames = providerMetadata.LogLinks.Select(link => link.LogName).ToList(), "log names", providerName);
+            TrySetMetadata(() => LogLinks = providerMetadata.LogLinks?.ToList(), "log links", providerName);
+            TrySetMetadata(() => LogNames = providerMetadata.LogLinks?.Select(link => link.LogName).ToList() ?? new List<string>(), "log names", providerName);
             TrySetMetadata(() => ParameterFilePath = providerMetadata.ParameterFilePath, "parameter file path", providerName);
             TrySetMetadata(() => ResourceFilePath = providerMetadata.ResourceFilePath, "resource file path", providerName);
-            TrySetMetadata(() => Opcodes = providerMetadata.Opcodes, "opcodes", providerName);
-            TrySetMetadata(() => Tasks = providerMetadata.Tasks, "tasks", providerName);
-            TrySetMetadata(() => Events = providerMetadata.Events, "events", providerName);
+            TrySetMetadata(() => Opcodes = providerMetadata.Opcodes?.ToList(), "opcodes", providerName);
+            TrySetMetadata(() => Tasks = providerMetadata.Tasks?.ToList(), "tasks", providerName);
+            TrySetMetadata(() => Events = providerMetadata.Events?.ToList(), "events", providerName);
         }
 
         private void TrySetMetadata(Action setAction, string metadataType, string providerName) {

--- a/Sources/EventViewerX/SearchEvents.GetPublisher.cs
+++ b/Sources/EventViewerX/SearchEvents.GetPublisher.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.Concurrent;
 using System.Diagnostics.Eventing.Reader;
+using System.Globalization;
 using System.Linq;
 
 namespace EventViewerX {
@@ -24,7 +25,7 @@ namespace EventViewerX {
             foreach (string providerName in session.GetProviderNames()) {
                 if (!_providerMetadataCache.TryGetValue(providerName, out var metadata)) {
                     try {
-                        using ProviderMetadata providerMetadata = new(providerName, session);
+                        using ProviderMetadata providerMetadata = new(providerName, session, CultureInfo.CurrentCulture);
                         metadata = new Metadata(providerName, providerMetadata);
                         _providerMetadataCache[providerName] = metadata;
                     } catch (EventLogInvalidDataException ex) {


### PR DESCRIPTION
## Summary
- avoid disposing ProviderMetadata before copying data
- update metadata container to duplicate lists
- add regression test for GetProviders

## Testing
- `dotnet test Sources/EventViewerX.Tests/EventViewerX.Tests.csproj --framework net8.0` *(fails: NETSDK1045 The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_687f5fc71804832e844608fb1b83d9ec