### PR TITLE
Fix ConvertSize negative handling

### DIFF
--- a/Sources/EventViewerX.Tests/TestEventLogDetails.cs
+++ b/Sources/EventViewerX.Tests/TestEventLogDetails.cs
@@ -1,0 +1,21 @@
+using System.Reflection;
+using Xunit;
+
+namespace EventViewerX.Tests;
+
+public class TestEventLogDetails {
+    [Fact]
+    public void ConvertSizeHandlesNonPositiveValues() {
+        var method = typeof(EventViewerX.EventLogDetails).GetMethod("ConvertSize", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(method);
+
+        double negative = (double)method!.Invoke(null, new object?[] { (double?)-1, "B", "MB", 2 })!;
+        Assert.Equal(0, negative);
+
+        double zero = (double)method.Invoke(null, new object?[] { (double?)0, "B", "MB", 2 })!;
+        Assert.Equal(0, zero);
+
+        double positive = (double)method.Invoke(null, new object?[] { (double?)1048576, "B", "MB", 2 })!;
+        Assert.Equal(1, positive);
+    }
+}

--- a/Sources/EventViewerX/EventLogDetails.cs
+++ b/Sources/EventViewerX/EventLogDetails.cs
@@ -131,11 +131,11 @@ public class EventLogDetails {
     /// <param name="precision">Number of decimal places.</param>
     /// <returns>Converted value.</returns>
     private static double ConvertSize(double? value, string fromUnit, string toUnit, int precision) {
-        if (!value.HasValue) {
+        if (!value.HasValue || value.Value <= 0) {
             return 0;
         }
 
-        double size = (double)value.Value;
+        double size = value.Value;
 
         switch (fromUnit.ToUpper()) {
             case "B":


### PR DESCRIPTION
## Summary
- ensure `EventLogDetails.ConvertSize` returns 0 for null or non-positive input
- add test verifying negative and zero values produce 0

## Testing
- `dotnet test Sources/EventViewerX.Tests/EventViewerX.Tests.csproj --framework net8.0` *(fails: NETSDK1045)*
- `pwsh -NoLogo -NoProfile -File ./PSEventViewer.Tests.ps1` *(fails: Invoke-Pester not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f5fd0c3d8832e8a38a66d90c16b98