### PR TITLE
Fix missing log info handling

### DIFF
--- a/Sources/EventViewerX.Tests/TestDisplayEventLogs.cs
+++ b/Sources/EventViewerX.Tests/TestDisplayEventLogs.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Diagnostics.Eventing.Reader;
+using Xunit;
+
+namespace EventViewerX.Tests;
+
+public class TestDisplayEventLogs {
+    [Fact]
+    public void CreateEventLogDetailsWithNullInfo() {
+        if (!OperatingSystem.IsWindows()) return;
+        using var session = new EventLogSession();
+        using var config = new EventLogConfiguration("Application", session);
+        var logger = new InternalLogger();
+        var details = new EventLogDetails(logger, Environment.MachineName, config, null);
+        Assert.Equal("Application", details.LogName);
+    }
+}

--- a/Sources/EventViewerX/SearchEvents.LogDetails.cs
+++ b/Sources/EventViewerX/SearchEvents.LogDetails.cs
@@ -45,6 +45,10 @@ public partial class SearchEvents : Settings {
                 _logger.WriteWarning("Couldn't get log information for " + logName + ". Error: " + ex.Message);
             }
 
+            if (logInfoObj == null) {
+                _logger.WriteVerbose("Log information is not available for " + logName);
+            }
+
             if (logConfig == null) {
                 _logger.WriteWarning("LogConfig is null for " + logName);
                 continue;


### PR DESCRIPTION
## Summary
- guard against null when log info can't be retrieved
- test constructing `EventLogDetails` with null log information

## Testing
- `dotnet test Sources/EventViewerX.Tests/EventViewerX.Tests.csproj -f net8.0 --no-build` *(fails: No test is available)*
- `pwsh -NoProfile -Command ./PSEventViewer.Tests.ps1` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_687f5fdde308832e8339fbda6133427d