### PR TITLE
Fix provider cache normalization

### DIFF
--- a/Sources/EventViewerX.Tests/TestProviderNormalization.cs
+++ b/Sources/EventViewerX.Tests/TestProviderNormalization.cs
@@ -1,0 +1,14 @@
+using System.Reflection;
+using Xunit;
+
+namespace EventViewerX.Tests;
+
+public class TestProviderNormalization {
+    [Fact]
+    public void TrimmedProviderNameReturned() {
+        var method = typeof(SearchEvents).GetMethod("NormalizeProviderName", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(method);
+        string result = (string)method!.Invoke(null, new object?[]{"  TestProvider  "})!;
+        Assert.Equal("TestProvider", result);
+    }
+}


### PR DESCRIPTION
## Summary
- normalize provider names before storing in provider metadata cache
- test provider name normalization

## Testing
- `dotnet build Sources/EventViewerX/EventViewerX.csproj -c Release` *(fails: NETSDK1045)*
- `dotnet test Sources/EventViewerX.sln --no-build --verbosity normal` *(fails: invalid arguments)*
- `pwsh -NoLogo -NoProfile -Command ./PSEventViewer.Tests.ps1` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_687ff851b080832e9d432d979cffa3db