### PR TITLE
Fix script execution tracking

### DIFF
--- a/Sources/EventViewerX.Tests/TestPowerShellScriptExecutionInfo.cs
+++ b/Sources/EventViewerX.Tests/TestPowerShellScriptExecutionInfo.cs
@@ -1,0 +1,18 @@
+using System.Reflection;
+using Xunit;
+
+namespace EventViewerX.Tests {
+    public class TestPowerShellScriptExecutionInfo {
+        [Fact]
+        public void ResetStateClearsCounter() {
+            var type = typeof(EventViewerX.PowerShellScriptExecutionInfo);
+            var field = type.GetField("_executionCount", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(field);
+            field!.SetValue(null, 5);
+            var method = type.GetMethod("ResetState", BindingFlags.Public | BindingFlags.Static);
+            Assert.NotNull(method);
+            method!.Invoke(null, null);
+            Assert.Equal(0, (int)field.GetValue(null)!);
+        }
+    }
+}

--- a/Sources/EventViewerX/PowerShellScriptExecutionInfo.cs
+++ b/Sources/EventViewerX/PowerShellScriptExecutionInfo.cs
@@ -2,12 +2,26 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.Eventing.Reader;
 using System.IO;
+using System.Threading;
 
 namespace EventViewerX {
     /// <summary>
     /// Represents details of a PowerShell engine start event.
     /// </summary>
     public class PowerShellScriptExecutionInfo {
+        private static int _executionCount;
+
+        /// <summary>
+        /// Gets the sequential index of this execution.
+        /// </summary>
+        public int Index { get; }
+
+        /// <summary>
+        /// Resets internal state used to track executions.
+        /// </summary>
+        public static void ResetState() {
+            Interlocked.Exchange(ref _executionCount, 0);
+        }
         /// <summary>
         /// Underlying event record containing script execution details.
         /// </summary>
@@ -21,6 +35,7 @@ namespace EventViewerX {
         internal PowerShellScriptExecutionInfo(EventRecord record, IDictionary<string, string?> data) {
             EventRecord = record;
             Data = data;
+            Index = Interlocked.Increment(ref _executionCount);
         }
     }
 


### PR DESCRIPTION
## Summary
- add resettable counter to `PowerShellScriptExecutionInfo`
- test state reset logic

## Testing
- `dotnet restore Sources/EventViewerX.Tests/EventViewerX.Tests.csproj --runtime win-x64 --no-cache` *(fails: NETSDK1045)*

------
https://chatgpt.com/codex/tasks/task_e_687ff841f3c0832e8c69b516d219ae26