### PR TITLE
Add dynamic LINQ filtering

### DIFF
--- a/Sources/EventViewerX.Examples/Examples.QueryBasic.cs
+++ b/Sources/EventViewerX.Examples/Examples.QueryBasic.cs
@@ -34,5 +34,10 @@
                 }
             }
         }
+
+        public static void QueryDynamicFilter() {
+            var events = SearchEvents.QueryLog("Application", [1000, 1001], linqExpression: "Id == 1000");
+            Console.WriteLine($"Filtered events: {events.Count()}");
+        }
     }
 }

--- a/Sources/EventViewerX.Tests/TestDynamicLinq.cs
+++ b/Sources/EventViewerX.Tests/TestDynamicLinq.cs
@@ -1,0 +1,14 @@
+using Xunit;
+using EventViewerX;
+using System.Linq;
+
+namespace EventViewerX.Tests {
+    public class TestDynamicLinq {
+        [Fact]
+        public void QueryLogWithDynamicExpressionFiltersResults() {
+            if (!OperatingSystem.IsWindows()) return;
+            var events = SearchEvents.QueryLog(KnownLog.System, new List<int> { 6005, 6006 }, linqExpression: "Id == 6005").ToList();
+            Assert.True(events.All(e => e.Id == 6005));
+        }
+    }
+}

--- a/Sources/EventViewerX/EventViewerX.csproj
+++ b/Sources/EventViewerX/EventViewerX.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
         <PackageReference Include="DnsClientX" Version="0.4.0" />
+        <PackageReference Include="System.Linq.Dynamic.Core" Version="1.2.22" />
   </ItemGroup>
   <ItemGroup>
         <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">


### PR DESCRIPTION
## Summary
- support dynamic LINQ expressions in `SearchEvents.QueryLog`
- expose dynamic filter across parallel queries
- demonstrate dynamic filter usage in examples
- cover dynamic filter with a new test
- include System.Linq.Dynamic.Core package

## Testing
- `dotnet test Sources/EventViewerX.Tests/EventViewerX.Tests.csproj -v minimal` *(fails: NETSDK1045)*
- `dotnet build Sources/EventViewerX/EventViewerX.csproj -v minimal` *(fails: NETSDK1045)*

------
https://chatgpt.com/codex/tasks/task_e_687ff82cbdc4832ea7d450d7cfc4b02f