### PR TITLE
fix(watcher): 🛡️ handle missing watcher list

### DIFF
--- a/Examples/Example.GetWatcherSafe.ps1
+++ b/Examples/Example.GetWatcherSafe.ps1
@@ -1,0 +1,7 @@
+# Demonstrates safe retrieval of watcher information
+$watcher = Get-EVXWatcher -Name 'DemoWatcher'
+if ($watcher) {
+    $watcher | Format-List
+} else {
+    Write-Host "Watcher 'DemoWatcher' not found."
+}

--- a/Sources/PSEventViewer/CmdletGetEVXWatcher.cs
+++ b/Sources/PSEventViewer/CmdletGetEVXWatcher.cs
@@ -28,6 +28,9 @@ namespace PSEventViewer {
         /// </summary>
         protected override void ProcessRecord() {
             var watchers = WatcherManager.GetWatchers(Name);
+            if (watchers == null) {
+                return;
+            }
             if (Id != null && Id.Length > 0) {
                 watchers = watchers.Where(w => Id.Contains(w.Id)).ToList();
             }

--- a/Tests/Get-EVXWatcher.Tests.ps1
+++ b/Tests/Get-EVXWatcher.Tests.ps1
@@ -1,0 +1,8 @@
+Describe 'Get-EVXWatcher - missing watcher' {
+    if (-not $IsWindows) { return }
+
+    It 'returns nothing and does not throw when watcher is absent' {
+        { Get-EVXWatcher -Name 'NonExistentWatcher' } | Should -Not -Throw
+        Get-EVXWatcher -Name 'NonExistentWatcher' | Should -BeNullOrEmpty
+    }
+}


### PR DESCRIPTION
## Summary
- return when WatcherManager returns no watchers
- cover missing watcher scenario with Pester test
- add example of safely retrieving watcher data

## Testing
- `dotnet build Sources/EventViewerX/EventViewerX.csproj -c Release -f net472`
- `dotnet build Sources/EventViewerX/EventViewerX.csproj -c Release -f net8.0`
- `dotnet build Sources/EventViewerX/EventViewerX.csproj -c Release -f net9.0`
- `dotnet build Sources/PSEventViewer/PSEventViewer.csproj -c Release -f net472`
- `dotnet build Sources/PSEventViewer/PSEventViewer.csproj -c Release -f net8.0`
- `dotnet test Sources/EventViewerX.Tests/EventViewerX.Tests.csproj -c Release`
- `pwsh PSEventViewer.Tests.ps1` *(fails: The term 'Write-Color' is not recognized...)*


------
https://chatgpt.com/codex/tasks/task_e_68911d774450832eb98e21385d47b0a5