### PR TITLE
fix(cmdlet): 🐛 return false when removal is skipped

### DIFF
--- a/Examples/Example.RemoveSourceWhatIf.ps1
+++ b/Examples/Example.RemoveSourceWhatIf.ps1
@@ -1,0 +1,8 @@
+Clear-Host
+Import-Module $PSScriptRoot\..\PSEventViewer.psd1 -Force
+
+# Register a temporary source
+Write-EVXEntry -LogName 'Application' -ProviderName 'TestWhatIfSource' -EventId 1 -Message 'Demo'
+
+# Preview removal of the source without deleting it
+Remove-EVXSource -SourceName 'TestWhatIfSource' -WhatIf

--- a/Sources/PSEventViewer/CmdletRemoveEVXSource.cs
+++ b/Sources/PSEventViewer/CmdletRemoveEVXSource.cs
@@ -35,6 +35,9 @@ public sealed class CmdletRemoveEVXSource : AsyncPSCmdlet {
                 if (EventLog.SourceExists(SourceName)) {
                     if (ShouldProcess(SourceName, "Delete event source")) {
                         EventLog.DeleteEventSource(SourceName);
+                    } else {
+                        WriteObject(false);
+                        return Task.CompletedTask;
                     }
                 } else {
                     WriteWarning($"Remove-EVXSource - Source {SourceName} was not found.");
@@ -45,6 +48,9 @@ public sealed class CmdletRemoveEVXSource : AsyncPSCmdlet {
                 if (EventLog.SourceExists(SourceName, MachineName)) {
                     if (ShouldProcess($"{SourceName} on {MachineName}", "Delete event source")) {
                         EventLog.DeleteEventSource(SourceName, MachineName);
+                    } else {
+                        WriteObject(false);
+                        return Task.CompletedTask;
                     }
                 } else {
                     WriteWarning($"Remove-EVXSource - Source {SourceName} was not found on {MachineName}.");

--- a/Tests/Remove-EVXSource.Tests.ps1
+++ b/Tests/Remove-EVXSource.Tests.ps1
@@ -1,13 +1,29 @@
 describe 'Remove-EVXSource cmdlet' {
     BeforeAll {
-        # Register a temporary source for removal
         $script:source = 'TestEVXSource'
-        Write-EVXEntry -LogName 'Application' -ProviderName $script:source -EventId 1 -Message 'test'
+    }
+
+    BeforeEach {
+        if (-not [System.Diagnostics.EventLog]::SourceExists($script:source)) {
+            Write-EVXEntry -LogName 'Application' -ProviderName $script:source -EventId 1 -Message 'test'
+        }
+    }
+
+    AfterAll {
+        if ([System.Diagnostics.EventLog]::SourceExists($script:source)) {
+            [System.Diagnostics.EventLog]::DeleteEventSource($script:source)
+        }
     }
 
     It 'removes existing source' {
         [System.Diagnostics.EventLog]::SourceExists($script:source) | Should -Be $true
         Remove-EVXSource -SourceName $script:source | Should -Be $true
         [System.Diagnostics.EventLog]::SourceExists($script:source) | Should -Be $false
+    }
+
+    It 'returns false when using -WhatIf' {
+        [System.Diagnostics.EventLog]::SourceExists($script:source) | Should -Be $true
+        Remove-EVXSource -SourceName $script:source -WhatIf | Should -Be $false
+        [System.Diagnostics.EventLog]::SourceExists($script:source) | Should -Be $true
     }
 }


### PR DESCRIPTION
## Summary
- ensure `Remove-EVXSource` returns `false` when `ShouldProcess` is declined
- add Pester test for `Remove-EVXSource` `-WhatIf` behavior
- add example showcasing `-WhatIf`

## Testing
- `dotnet build Sources/PSEventViewer/PSEventViewer.csproj -f net472`
- `dotnet build Sources/PSEventViewer/PSEventViewer.csproj -f net8.0`
- `dotnet build Sources/EventViewerX/EventViewerX.csproj -f net9.0`
- `pwsh -NoLogo -NoProfile -Command ./PSEventViewer.Tests.ps1` *(fails: The term 'Invoke-Pester' is not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_68911d690afc832eb856454b35a798d5