### PR TITLE
Respect ErrorAction in Write-EVXEntry and add failure test

### DIFF
--- a/Examples/Example.WriteEventErrorHandling.ps1
+++ b/Examples/Example.WriteEventErrorHandling.ps1
@@ -1,0 +1,8 @@
+Clear-Host
+Import-Module $PSScriptRoot\..\PSEventViewer.psd1 -Force
+
+try {
+    Write-EVXEntry -LogName 'Application' -ProviderName 'TestProvider' -Message 'Test message' -EventId 1000 -Category 40000 -ErrorAction Stop
+} catch {
+    Write-Warning -Message "Write-EVXEntry failed: $($_.Exception.Message)"
+}

--- a/Tests/Write-EVXEntry.Tests.ps1
+++ b/Tests/Write-EVXEntry.Tests.ps1
@@ -1,0 +1,5 @@
+Describe 'Write-EVXEntry cmdlet' {
+    It 'throws terminating error with -ErrorAction Stop when write fails' {
+        { Write-EVXEntry -LogName 'Application' -ProviderName 'TestProvider' -Message 'Test message' -EventId 1000 -Category 40000 -ErrorAction Stop } | Should -Throw
+    }
+}


### PR DESCRIPTION
## Summary
- wrap SearchEvents.WriteEvent in try/catch and honor ErrorAction preference
- add Pester test ensuring -ErrorAction Stop throws on write failure
- include example script for graceful write failure handling

## Testing
- `dotnet build Sources/PSEventViewer/PSEventViewer.csproj -f net472`
- `dotnet build Sources/PSEventViewer/PSEventViewer.csproj -f net8.0`
- `dotnet build Sources/EventViewerX/EventViewerX.csproj -f net9.0`
- `dotnet test Sources/EventViewerX.Tests/EventViewerX.Tests.csproj -f net8.0`
- `pwsh -NoLogo -NoProfile PSEventViewer.Tests.ps1` *(fails: Write-Color/Invoke-Pester not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892f674806c832e916862b44ab377dd