### PR TITLE
refactor: ♻️ use properties for cmdlet parameters

### DIFF
--- a/Sources/PSEventViewer/CmdletGetEVXEvent.cs
+++ b/Sources/PSEventViewer/CmdletGetEVXEvent.cs
@@ -27,13 +27,13 @@ public sealed class CmdletGetEVXEvent : AsyncPSCmdlet {
     /// </summary>
     [Parameter(Mandatory = true, Position = 0, ParameterSetName = "RecordId")]
     [Parameter(Mandatory = true, Position = 0, ParameterSetName = "GenericEvents")]
-    public string LogName;
+    public string LogName { get; set; }
 
     /// <summary>
     /// Path to an event log file for offline analysis.
     /// </summary>
     [Parameter(Mandatory = true, ParameterSetName = "PathEvents")]
-    public string Path;
+    public string Path { get; set; }
 
     /// <summary>
     /// Event identifiers used to filter results.
@@ -41,14 +41,14 @@ public sealed class CmdletGetEVXEvent : AsyncPSCmdlet {
     [Alias("Id")]
     [Parameter(Mandatory = false, Position = 1, ParameterSetName = "GenericEvents")]
     [Parameter(Mandatory = false, ParameterSetName = "PathEvents")]
-    public List<int> EventId = null;
+    public List<int> EventId { get; set; }
 
     /// <summary>
     /// Specific event record identifiers to retrieve.
     /// </summary>
     [Alias("RecordId")]
     [Parameter(Mandatory = false, ParameterSetName = "RecordId")]
-    public List<long> EventRecordId = null;
+    public List<long> EventRecordId { get; set; }
 
     /// <summary>
     /// Path to a file storing last processed record ID.
@@ -57,7 +57,7 @@ public sealed class CmdletGetEVXEvent : AsyncPSCmdlet {
     [Parameter(Mandatory = false, ParameterSetName = "GenericEvents")]
     [Parameter(Mandatory = false, ParameterSetName = "NamedEvents")]
     [Parameter(Mandatory = false, ParameterSetName = "PathEvents")]
-    public string RecordIdFile;
+    public string RecordIdFile { get; set; }
 
     /// <summary>
     /// Identifier used when persisting record IDs to allow multiple jobs to share a file.
@@ -66,7 +66,7 @@ public sealed class CmdletGetEVXEvent : AsyncPSCmdlet {
     [Parameter(Mandatory = false, ParameterSetName = "GenericEvents")]
     [Parameter(Mandatory = false, ParameterSetName = "NamedEvents")]
     [Parameter(Mandatory = false, ParameterSetName = "PathEvents")]
-    public string RecordIdKey;
+    public string RecordIdKey { get; set; }
 
     /// <summary>
     /// Computer names against which to run the query.
@@ -76,26 +76,26 @@ public sealed class CmdletGetEVXEvent : AsyncPSCmdlet {
     [Parameter(Mandatory = false, ParameterSetName = "GenericEvents")]
     [Parameter(Mandatory = false, ParameterSetName = "NamedEvents")]
     [Parameter(Mandatory = false, ParameterSetName = "ListLog")]
-    public List<string> MachineName;
+    public List<string> MachineName { get; set; }
 
     /// <summary>
     /// Event provider name to filter results.
     /// </summary>
     [Alias("Source", "Provider")]
     [Parameter(Mandatory = false, ParameterSetName = "GenericEvents")]
-    public string ProviderName;
+    public string ProviderName { get; set; }
 
     /// <summary>
     /// Keywords used to filter events.
     /// </summary>
     [Parameter(Mandatory = false, ParameterSetName = "GenericEvents")]
-    public Keywords? Keywords;
+    public Keywords? Keywords { get; set; }
 
     /// <summary>
     /// Event level (e.g. Error, Warning) used for filtering.
     /// </summary>
     [Parameter(Mandatory = false, ParameterSetName = "GenericEvents")]
-    public Level? Level;
+    public Level? Level { get; set; }
 
     /// <summary>
     /// Start time for the event query.
@@ -104,7 +104,7 @@ public sealed class CmdletGetEVXEvent : AsyncPSCmdlet {
     [Parameter(Mandatory = false, ParameterSetName = "NamedEvents")]
     [Parameter(Mandatory = false, ParameterSetName = "GenericEvents")]
     [Parameter(Mandatory = false, ParameterSetName = "PathEvents")]
-    public DateTime? StartTime;
+    public DateTime? StartTime { get; set; }
 
     /// <summary>
     /// End time for the event query.
@@ -113,20 +113,20 @@ public sealed class CmdletGetEVXEvent : AsyncPSCmdlet {
     [Parameter(Mandatory = false, ParameterSetName = "NamedEvents")]
     [Parameter(Mandatory = false, ParameterSetName = "GenericEvents")]
     [Parameter(Mandatory = false, ParameterSetName = "PathEvents")]
-    public DateTime? EndTime;
+    public DateTime? EndTime { get; set; }
 
     /// <summary>
     /// Relative time period for filtering events.
     /// </summary>
     [Parameter(Mandatory = false, ParameterSetName = "GenericEvents")]
     [Parameter(Mandatory = false, ParameterSetName = "NamedEvents")]
-    public TimePeriod? TimePeriod;
+    public TimePeriod? TimePeriod { get; set; }
 
     /// <summary>
     /// User identifier used to filter events.
     /// </summary>
     [Parameter(Mandatory = false, ParameterSetName = "GenericEvents")]
-    public string UserId;
+    public string UserId { get; set; }
 
     /// <summary>
     /// Filters events by matching their formatted message against the provided regular expression.
@@ -135,7 +135,7 @@ public sealed class CmdletGetEVXEvent : AsyncPSCmdlet {
     [Parameter(Mandatory = false, ParameterSetName = "GenericEvents")]
     [Parameter(Mandatory = false, ParameterSetName = "NamedEvents")]
     [Parameter(Mandatory = false, ParameterSetName = "PathEvents")]
-    public Regex MessageRegex;
+    public Regex MessageRegex { get; set; }
 
     /// <summary>
     /// Number of parallel threads used for queries.
@@ -144,7 +144,7 @@ public sealed class CmdletGetEVXEvent : AsyncPSCmdlet {
     [Parameter(Mandatory = false, ParameterSetName = "GenericEvents")]
     [Parameter(Mandatory = false, ParameterSetName = "NamedEvents")]
     [ValidateRange(1, int.MaxValue)]
-    public int NumberOfThreads = 8;
+    public int NumberOfThreads { get; set; } = 8;
 
     /// <summary>
     /// Maximum number of events to return.
@@ -153,7 +153,7 @@ public sealed class CmdletGetEVXEvent : AsyncPSCmdlet {
     [Parameter(Mandatory = false, ParameterSetName = "GenericEvents")]
     [Parameter(Mandatory = false, ParameterSetName = "NamedEvents")]
     [Parameter(Mandatory = false, ParameterSetName = "PathEvents")]
-    public int MaxEvents = 0;
+    public int MaxEvents { get; set; }
 
     /// <summary>
     /// Controls whether queries run in parallel or sequentially.
@@ -162,7 +162,7 @@ public sealed class CmdletGetEVXEvent : AsyncPSCmdlet {
     [Parameter(Mandatory = false, ParameterSetName = "GenericEvents")]
     [Parameter(Mandatory = false, ParameterSetName = "NamedEvents")]
     [Parameter(Mandatory = false, ParameterSetName = "PathEvents")]
-    public ParallelOption ParallelOption = ParallelOption.Parallel;
+    public ParallelOption ParallelOption { get; set; } = ParallelOption.Parallel;
 
     /// <summary>
     /// Expands event data into individual properties.
@@ -171,31 +171,31 @@ public sealed class CmdletGetEVXEvent : AsyncPSCmdlet {
     [Parameter(Mandatory = false, ParameterSetName = "GenericEvents")]
     [Parameter(Mandatory = false, ParameterSetName = "NamedEvents")]
     [Parameter(Mandatory = false, ParameterSetName = "PathEvents")]
-    public SwitchParameter Expand;
+    public SwitchParameter Expand { get; set; }
 
     /// <summary>
     /// Reads events from oldest to newest when querying files.
     /// </summary>
     [Parameter(Mandatory = false, ParameterSetName = "PathEvents")]
-    public SwitchParameter Oldest;
+    public SwitchParameter Oldest { get; set; }
 
     /// <summary>
     /// Hashtable filter for named event data when querying files.
     /// </summary>
     [Parameter(Mandatory = false, ParameterSetName = "PathEvents")]
-    public Hashtable NamedDataFilter;
+    public Hashtable NamedDataFilter { get; set; }
 
     /// <summary>
     /// Hashtable filter to exclude named event data when querying files.
     /// </summary>
     [Parameter(Mandatory = false, ParameterSetName = "PathEvents")]
-    public Hashtable NamedDataExcludeFilter;
+    public Hashtable NamedDataExcludeFilter { get; set; }
 
     /// <summary>
     /// Disables parallel processing of file queries.
     /// </summary>
     [Parameter(Mandatory = false, ParameterSetName = "PathEvents")]
-    public SwitchParameter DisableParallel;
+    public SwitchParameter DisableParallel { get; set; }
 
     /// <summary>
     /// Returns results as an array instead of streaming them.
@@ -205,13 +205,13 @@ public sealed class CmdletGetEVXEvent : AsyncPSCmdlet {
     [Parameter(Mandatory = false, ParameterSetName = "NamedEvents")]
     [Parameter(Mandatory = false, ParameterSetName = "PathEvents")]
     [Parameter(Mandatory = false, ParameterSetName = "ListLog")]
-    public SwitchParameter AsArray;
+    public SwitchParameter AsArray { get; set; }
 
     /// <summary>
     /// Predefined named events to query.
     /// </summary>
     [Parameter(Mandatory = true, ParameterSetName = "NamedEvents")]
-    public NamedEvents[] Type;
+    public NamedEvents[] Type { get; set; }
 
     /// <summary>
     /// The list log parameter is used to list the logs on the machine.
@@ -219,7 +219,7 @@ public sealed class CmdletGetEVXEvent : AsyncPSCmdlet {
     /// When using wildcards, you can use the * character to match zero or more characters, and the ? character to match a single character.
     /// </summary>
     [Parameter(Mandatory = true, ParameterSetName = "ListLog")]
-    public string[] ListLog = { "*" };
+    public string[] ListLog { get; set; } = new[] { "*" };
 
 
     /// <summary>

--- a/Sources/PSEventViewer/CmdletGetEVXFilter.cs
+++ b/Sources/PSEventViewer/CmdletGetEVXFilter.cs
@@ -12,93 +12,93 @@ public sealed class CmdletGetEVXFilter : AsyncPSCmdlet {
     /// Event identifiers to include in the filter.
     /// </summary>
     [Parameter]
-    public string[] ID;
+    public string[] ID { get; set; }
 
     /// <summary>
     /// Event record identifiers to include in the filter.
     /// </summary>
     [Alias("RecordID")]
     [Parameter]
-    public string[] EventRecordID;
+    public string[] EventRecordID { get; set; }
 
     /// <summary>
     /// Start time for the filter range.
     /// </summary>
     [Parameter]
-    public DateTime? StartTime;
+    public DateTime? StartTime { get; set; }
 
     /// <summary>
     /// End time for the filter range.
     /// </summary>
     [Parameter]
-    public DateTime? EndTime;
+    public DateTime? EndTime { get; set; }
 
     /// <summary>
     /// Specific event data values to filter on.
     /// </summary>
     [Parameter]
-    public string[] Data;
+    public string[] Data { get; set; }
 
     /// <summary>
     /// Provider names to include in the filter.
     /// </summary>
     [Parameter]
-    public string[] ProviderName;
+    public string[] ProviderName { get; set; }
 
     /// <summary>
     /// Keywords to include in the filter.
     /// </summary>
     [Parameter]
-    public long[] Keywords;
+    public long[] Keywords { get; set; }
 
     /// <summary>
     /// Event levels to include in the filter.
     /// </summary>
     [ValidateSet("Critical", "Error", "Informational", "LogAlways", "Verbose", "Warning")]
     [Parameter]
-    public string[] Level;
+    public string[] Level { get; set; }
 
     /// <summary>
     /// User identifiers to include in the filter.
     /// </summary>
     [Parameter]
-    public string[] UserID;
+    public string[] UserID { get; set; }
 
     /// <summary>
     /// Hashtable specifying named data filters.
     /// </summary>
     [Parameter]
-    public Hashtable[] NamedDataFilter;
+    public Hashtable[] NamedDataFilter { get; set; }
 
     /// <summary>
     /// Hashtable specifying named data to exclude from the filter.
     /// </summary>
     [Parameter]
-    public Hashtable[] NamedDataExcludeFilter;
+    public Hashtable[] NamedDataExcludeFilter { get; set; }
 
     /// <summary>
     /// Event identifiers to exclude from the filter.
     /// </summary>
     [Parameter]
-    public string[] ExcludeID;
+    public string[] ExcludeID { get; set; }
 
     /// <summary>
     /// Name of the log associated with the filter.
     /// </summary>
     [Parameter]
-    public string LogName;
+    public string LogName { get; set; }
 
     /// <summary>
     /// Path of the log file to generate the filter for.
     /// </summary>
     [Parameter]
-    public string Path;
+    public string Path { get; set; }
 
     /// <summary>
     /// When set, outputs only the XPath expression without formatting.
     /// </summary>
     [Parameter]
-    public SwitchParameter XPathOnly;
+    public SwitchParameter XPathOnly { get; set; }
 
     /// <summary>
     /// Builds the XPath filter based on specified parameters.

--- a/Sources/PSEventViewer/CmdletWriteEVXEntry.cs
+++ b/Sources/PSEventViewer/CmdletWriteEVXEntry.cs
@@ -13,53 +13,53 @@ public sealed class CmdletWriteEVXEntry : AsyncPSCmdlet {
     /// </summary>
     [Alias("ComputerName", "ServerName")]
     [Parameter(Mandatory = false, ParameterSetName = "GenericEvents")]
-    public string MachineName;
+    public string MachineName { get; set; }
 
     /// <summary>
     /// Name of the event log where the entry will be written.
     /// </summary>
     [Parameter(Mandatory = true, Position = 0, ParameterSetName = "RecordId")]
     [Parameter(Mandatory = true, Position = 0, ParameterSetName = "GenericEvents")]
-    public string LogName;
+    public string LogName { get; set; }
 
     /// <summary>
     /// Name of the provider that writes the entry.
     /// </summary>
     [Alias("Source", "Provider")]
     [Parameter(Mandatory = true, ParameterSetName = "GenericEvents")]
-    public string ProviderName;
+    public string ProviderName { get; set; }
 
     /// <summary>
     /// Category for the event entry.
     /// </summary>
     [Parameter(Mandatory = false, ParameterSetName = "GenericEvents")]
-    public int Category;
+    public int Category { get; set; }
 
     /// <summary>
     /// Type of the event log entry.
     /// </summary>
     [Alias("EntryType")]
     [Parameter(Mandatory = false, ParameterSetName = "GenericEvents")]
-    public System.Diagnostics.EventLogEntryType EventLogEntryType = System.Diagnostics.EventLogEntryType.Information;
+    public System.Diagnostics.EventLogEntryType EventLogEntryType { get; set; } = System.Diagnostics.EventLogEntryType.Information;
 
     /// <summary>
     /// Identifier for the event entry.
     /// </summary>
     [Alias("Id")]
     [Parameter(Mandatory = true, ParameterSetName = "GenericEvents")]
-    public int EventId;
+    public int EventId { get; set; }
 
     /// <summary>
     /// Message for the event entry.
     /// </summary>
     [Parameter(Mandatory = true, ParameterSetName = "GenericEvents")]
-    public string Message;
+    public string Message { get; set; }
 
     /// <summary>
     /// Additional custom fields to include with the event.
     /// </summary>
     [Parameter(Mandatory = false, ParameterSetName = "GenericEvents")]
-    public string[] AdditionalFields;
+    public string[] AdditionalFields { get; set; }
 
     private ActionPreference errorAction;
 


### PR DESCRIPTION
## Summary
- refactor cmdlets to use auto-properties for parameter binding
- preserve existing parameter attributes

## Testing
- `dotnet build Sources/EventViewerX.sln`
- `pwsh -NoLogo -NoProfile -File PSEventViewer.Tests.ps1` *(fails: No match was found for the specified search criteria and module name 'Pester')*

------
https://chatgpt.com/codex/tasks/task_e_68979f6f0200832ebfb658d80d2229c6