### PR TITLE
fix(query): ignore empty providerName filter

### DIFF
--- a/Sources/EventViewerX.Tests/TestQueryLogFile.cs
+++ b/Sources/EventViewerX.Tests/TestQueryLogFile.cs
@@ -13,5 +13,14 @@ namespace EventViewerX.Tests {
             var events = SearchEvents.QueryLogFile(quotedPath).ToList();
             Assert.NotEmpty(events);
         }
+
+        [Fact]
+        public void QueryLogFileIgnoresEmptyProviderName() {
+            if (!OperatingSystem.IsWindows()) return;
+            string path = Path.Combine("..", "..", "..", "..", "..", "Tests", "Logs", "Active Directory Web Services.evtx");
+            var eventsWithoutFilter = SearchEvents.QueryLogFile(path).ToList();
+            var eventsWithEmptyProvider = SearchEvents.QueryLogFile(path, providerName: "").ToList();
+            Assert.Equal(eventsWithoutFilter.Count, eventsWithEmptyProvider.Count);
+        }
     }
 }

--- a/Sources/EventViewerX/SearchEvents.QueryLog.File.cs
+++ b/Sources/EventViewerX/SearchEvents.QueryLog.File.cs
@@ -27,7 +27,7 @@ public partial class SearchEvents : Settings {
 
         // Check if we have any filters that require an XML query
         bool hasFilters = namedDataFilter != null || namedDataExcludeFilter != null || eventIds != null ||
-                         providerName != null || keywords != null || level != null || startTime != null ||
+                         !string.IsNullOrEmpty(providerName) || keywords != null || level != null || startTime != null ||
                          endTime != null || userId != null || eventRecordId != null;
 
         EventLogQuery query;


### PR DESCRIPTION
## Summary
- ensure `QueryLogFile` skips provider filter when name is empty
- test that empty provider names return same events as no provider

## Testing
- `dotnet build Sources/EventViewerX.sln`
- `dotnet test Sources/EventViewerX.Tests/EventViewerX.Tests.csproj`
- `pwsh PSEventViewer.Tests.ps1` *(fails: Write-Color not recognized; PSSharedGoods module missing)*

------
https://chatgpt.com/codex/tasks/task_e_6897bd7ae3fc832e9167f27777fd2797