### PR TITLE
chore(build): enable nullable reference types

### DIFF
--- a/Sources/EventViewerX/EventViewerX.csproj
+++ b/Sources/EventViewerX/EventViewerX.csproj
@@ -10,6 +10,7 @@
         <Company>Evotec</Company>
         <Authors>Przemyslaw Klys</Authors>
         <LangVersion>latest</LangVersion>
+        <Nullable>enable</Nullable>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <IsWindows>true</IsWindows>
         <SupportedOSPlatform>windows</SupportedOSPlatform>

--- a/Sources/PSEventViewer/PSEventViewer.csproj
+++ b/Sources/PSEventViewer/PSEventViewer.csproj
@@ -10,6 +10,7 @@
         <Company>Evotec</Company>
         <Authors>Przemyslaw Klys</Authors>
         <LangVersion>latest</LangVersion>
+        <Nullable>enable</Nullable>
         <IsWindows>true</IsWindows>
         <SupportedOSPlatform>windows</SupportedOSPlatform>
     </PropertyGroup>


### PR DESCRIPTION
## Summary
- enable nullable reference types for EventViewerX and PSEventViewer
- remove blanket nullability warning suppression

## Testing
- `dotnet build Sources/EventViewerX/EventViewerX.csproj`
- `dotnet build Sources/PSEventViewer/PSEventViewer.csproj`


------
https://chatgpt.com/codex/tasks/task_e_6897bd72895c832eb29c486d48d22863