### PR TITLE
refactor(build): global usings and package cleanup

### DIFF
--- a/Sources/EventViewerX/EventViewerX.csproj
+++ b/Sources/EventViewerX/EventViewerX.csproj
@@ -44,23 +44,4 @@
         <PackageReference Include="System.DirectoryServices" Version="9.0.6" />
         <PackageReference Include="System.Diagnostics.EventLog" Version="9.0.6" />
     </ItemGroup>
-
-    <ItemGroup>
-        <Using Include="System.Collections" />
-        <Using Include="System.Threading.Tasks" />
-        <Using Include="System.Collections.Concurrent" />
-        <Using Include="System.Threading" />
-        <Using Include="System" />
-        <Using Include="System.Collections.Generic" />
-        <Using Include="System.Linq" />
-        <Using Include="System.Text" />
-        <Using Include="System.IO" />
-        <Using Include="System.Net" />
-        <Using Include="System.Diagnostics" />
-        <Using Include="System.Runtime.Versioning" />
-    </ItemGroup>
-    <ItemGroup>
-        <Folder Include="Properties\" />
-        <Folder Include="Rules\CertificateAuthority\" />
-    </ItemGroup>
 </Project>

--- a/Sources/EventViewerX/GlobalUsings.cs
+++ b/Sources/EventViewerX/GlobalUsings.cs
@@ -1,0 +1,12 @@
+﻿global using System.Collections;
+global using System.Threading.Tasks;
+global using System.Collections.Concurrent;
+global using System.Threading;
+global using System;
+global using System.Collections.Generic;
+global using System.Linq;
+global using System.Text;
+global using System.IO;
+global using System.Net;
+global using System.Diagnostics;
+global using System.Runtime.Versioning;

--- a/Sources/PSEventViewer/GlobalUsings.cs
+++ b/Sources/PSEventViewer/GlobalUsings.cs
@@ -1,0 +1,13 @@
+﻿global using System.Collections;
+global using System.Management.Automation;
+global using System.Threading.Tasks;
+global using System.Collections.Concurrent;
+global using System.Threading;
+global using System;
+global using System.Collections.Generic;
+global using System.Linq;
+global using System.Text;
+global using System.IO;
+global using System.Net;
+global using System.Diagnostics;
+global using EventViewerX;

--- a/Sources/PSEventViewer/PSEventViewer.csproj
+++ b/Sources/PSEventViewer/PSEventViewer.csproj
@@ -18,7 +18,7 @@
         <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" PrivateAssets="all" />
     </ItemGroup>
   <ItemGroup>
-      <ProjectReference Include="..\EventViewerX\EventViewerX.csproj" />
+      <ProjectReference Include="..\\EventViewerX\\EventViewerX.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' or '$(TargetFramework)' == 'netstandard2.0' ">
@@ -29,22 +29,6 @@
     <PropertyGroup>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     </PropertyGroup>
-
-    <ItemGroup>
-        <Using Include="System.Collections" />
-        <Using Include="System.Management.Automation" />
-        <Using Include="System.Threading.Tasks" />
-        <Using Include="System.Collections.Concurrent" />
-        <Using Include="System.Threading" />
-        <Using Include="System" />
-        <Using Include="System.Collections.Generic" />
-        <Using Include="System.Linq" />
-        <Using Include="System.Text" />
-        <Using Include="System.IO" />
-        <Using Include="System.Net" />
-        <Using Include="System.Diagnostics" />
-        <Using Include="EventViewerX" />
-    </ItemGroup>
 
     <!-- We need to remove PowerShell conflicting libraries as it will break output -->
     <Target Name="RemoveFilesAfterBuild" AfterTargets="Build">


### PR DESCRIPTION
## Summary
- move project-level using directives to GlobalUsings.cs
- streamline framework-specific package references

## Testing
- `dotnet restore Sources/EventViewerX/EventViewerX.csproj`
- `dotnet build Sources/EventViewerX/EventViewerX.csproj`
- `dotnet restore Sources/PSEventViewer/PSEventViewer.csproj`
- `dotnet build Sources/PSEventViewer/PSEventViewer.csproj` *(fails: MatejKafka.XmlDoc2CmdletDoc exited with code 150)*

------
https://chatgpt.com/codex/tasks/task_e_68a069be2e2c832ea0353ca3db262776