### PR TITLE
style(eventviewer): reduce nullable warnings

### DIFF
--- a/Sources/EventViewerX/Definitions/GroupPolicy.cs
+++ b/Sources/EventViewerX/Definitions/GroupPolicy.cs
@@ -5,9 +5,9 @@
 /// </summary>
 public class GroupPolicy {
     /// <summary>Name of the Group Policy Object.</summary>
-    public string GpoName { get; set; }
+    public string GpoName { get; set; } = string.Empty;
     /// <summary>Identifier of the Group Policy Object.</summary>
-    public string GpoId { get; set; }
+    public string GpoId { get; set; } = string.Empty;
     /// <summary>Domain hosting the Group Policy Object.</summary>
-    public string GpoDomain { get; set; }
+    public string GpoDomain { get; set; } = string.Empty;
 }

--- a/Sources/EventViewerX/Metadata.cs
+++ b/Sources/EventViewerX/Metadata.cs
@@ -8,27 +8,27 @@ namespace EventViewerX {
     /// Lightweight provider metadata container.
     /// </summary>
     public class Metadata {
-        public string ProviderName;
-        public string DisplayName;
-        public List<string> LogNames;
-        public Guid Id;
+        public string ProviderName { get; }
+        public string? DisplayName { get; private set; }
+        public List<string> LogNames { get; private set; } = new();
+        public Guid Id { get; }
 
-        public IList<EventLogLink> LogLinks { get; set; }
-        public IEnumerable<EventMetadata> Events { get; set; }
+        public IList<EventLogLink>? LogLinks { get; private set; }
+        public IEnumerable<EventMetadata>? Events { get; private set; }
 
-        public IList<EventKeyword> Keywords { get; set; }
+        public IList<EventKeyword>? Keywords { get; private set; }
 
-        public IList<EventOpcode> Opcodes { get; set; }
+        public IList<EventOpcode>? Opcodes { get; private set; }
 
-        public string MessageFilePath { get; set; }
+        public string MessageFilePath { get; private set; } = string.Empty;
 
-        public string ResourceFilePath { get; set; }
+        public string ResourceFilePath { get; private set; } = string.Empty;
 
-        public string ParameterFilePath { get; set; }
+        public string ParameterFilePath { get; private set; } = string.Empty;
 
-        public IList<EventTask> Tasks { get; set; }
+        public IList<EventTask>? Tasks { get; private set; }
 
-        public List<string> Errors = new List<string>();
+        public List<string> Errors { get; } = new();
 
         public Metadata(string providerName, ProviderMetadata providerMetadata) {
             ProviderName = providerName;

--- a/Sources/EventViewerX/RestoredPowerShellScript.cs
+++ b/Sources/EventViewerX/RestoredPowerShellScript.cs
@@ -9,27 +9,27 @@ public class RestoredPowerShellScript {
     /// <summary>
     /// Identifier of the script block.
     /// </summary>
-    public string ScriptBlockId { get; set; }
+    public string ScriptBlockId { get; set; } = string.Empty;
 
     /// <summary>
     /// Full script text reconstructed from events.
     /// </summary>
-    public string Script { get; set; }
+    public string Script { get; set; } = string.Empty;
 
     /// <summary>
     /// Event records that compose the script.
     /// </summary>
-    public IReadOnlyList<EventRecord> Events { get; set; }
+    public IReadOnlyList<EventRecord> Events { get; set; } = Array.Empty<EventRecord>();
 
     /// <summary>
     /// Primary event record for convenience access.
     /// </summary>
-    public EventRecord EventRecord => Events?[0];
+    public EventRecord? EventRecord => Events.Count > 0 ? Events[0] : null;
 
     /// <summary>
     /// Parsed data dictionary from the event.
     /// </summary>
-    public IDictionary<string, string?> Data { get; set; }
+    public IDictionary<string, string?> Data { get; set; } = new Dictionary<string, string?>();
 
     /// <summary>
     /// Saves the script to the specified directory.

--- a/Sources/EventViewerX/Rules/Kerberos/KerberosServiceTicket.cs
+++ b/Sources/EventViewerX/Rules/Kerberos/KerberosServiceTicket.cs
@@ -14,13 +14,13 @@ public class KerberosServiceTicket : EventRuleBase
         // Simple rule - always handle if event ID and log name match
         return true;
     }
-    public string Computer;
-    public string Action;
-    public string AccountName;
-    public string ServiceName;
-    public string IpAddress;
-    public string IpPort;
-    public string TicketOptions;
+    public string Computer = string.Empty;
+    public string Action = string.Empty;
+    public string AccountName = string.Empty;
+    public string ServiceName = string.Empty;
+    public string IpAddress = string.Empty;
+    public string IpPort = string.Empty;
+    public string TicketOptions = string.Empty;
     public TicketEncryptionType? EncryptionType;
     public bool WeakEncryptionAlgorithm;
     public bool UnusualTicketOptions;

--- a/Sources/EventViewerX/Rules/Windows/ScheduledTaskCreated.cs
+++ b/Sources/EventViewerX/Rules/Windows/ScheduledTaskCreated.cs
@@ -14,11 +14,11 @@ public class ScheduledTaskCreated : EventRuleBase {
         return true;
     }
     /// <summary>Computer where the task was created.</summary>
-    public string Computer;
+    public string Computer = string.Empty;
     /// <summary>Name of the created task.</summary>
-    public string TaskName;
+    public string TaskName = string.Empty;
     /// <summary>Author of the task definition.</summary>
-    public string Author;
+    public string Author = string.Empty;
     /// <summary>Creation timestamp read from the task XML.</summary>
     public DateTime? Created;
     /// <summary>Time the event occurred.</summary>

--- a/Sources/EventViewerX/SearchEvents.QueryLog.Parallel.cs
+++ b/Sources/EventViewerX/SearchEvents.QueryLog.Parallel.cs
@@ -8,9 +8,9 @@ using System.Threading.Tasks;
 namespace EventViewerX;
 
 public partial class SearchEvents : Settings {
-    public static async IAsyncEnumerable<EventObject> QueryLogsParallel(string logName, List<int> eventIds = null, List<string> machineNames = null, string providerName = null, Keywords? keywords = null, Level? level = null, DateTime? startTime = null, DateTime? endTime = null, string userId = null, int maxEvents = 0, int maxThreads = 8, List<long> eventRecordId = null, TimePeriod? timePeriod = null, [EnumeratorCancellation] CancellationToken cancellationToken = default) {
+    public static async IAsyncEnumerable<EventObject> QueryLogsParallel(string logName, List<int>? eventIds = null, List<string?>? machineNames = null, string? providerName = null, Keywords? keywords = null, Level? level = null, DateTime? startTime = null, DateTime? endTime = null, string? userId = null, int maxEvents = 0, int maxThreads = 8, List<long>? eventRecordId = null, TimePeriod? timePeriod = null, [EnumeratorCancellation] CancellationToken cancellationToken = default) {
         if (machineNames == null || !machineNames.Any()) {
-            machineNames = new List<string> { null };
+            machineNames = new List<string?> { null };
             _logger.WriteVerbose("No machine names provided, querying the local machine.");
         } else {
             _logger.WriteVerbose($"Machine names provided. Creating tasks for each machine on the list: {string.Join(", ", machineNames)}");
@@ -59,7 +59,7 @@ public partial class SearchEvents : Settings {
         await whenAllTask;
     }
 
-    public static async Task<IEnumerable<EventObject>> QueryLogsParallelAsync(string logName, List<int> eventIds = null, List<string> machineNames = null, string providerName = null, Keywords? keywords = null, Level? level = null, DateTime? startTime = null, DateTime? endTime = null, string userId = null, int maxEvents = 0, int maxThreads = 8, List<long> eventRecordId = null, TimePeriod? timePeriod = null, CancellationToken cancellationToken = default) {
+    public static async Task<IEnumerable<EventObject>> QueryLogsParallelAsync(string logName, List<int>? eventIds = null, List<string?>? machineNames = null, string? providerName = null, Keywords? keywords = null, Level? level = null, DateTime? startTime = null, DateTime? endTime = null, string? userId = null, int maxEvents = 0, int maxThreads = 8, List<long>? eventRecordId = null, TimePeriod? timePeriod = null, CancellationToken cancellationToken = default) {
         var results = new List<EventObject>();
         await foreach (var ev in QueryLogsParallel(logName, eventIds, machineNames, providerName, keywords, level, startTime, endTime, userId, maxEvents, maxThreads, eventRecordId, timePeriod, cancellationToken)) {
             results.Add(ev);
@@ -67,15 +67,15 @@ public partial class SearchEvents : Settings {
         return results;
     }
 
-    public static IAsyncEnumerable<EventObject> QueryLogsParallel(KnownLog logName, List<int> eventIds = null, List<string> machineNames = null, string providerName = null, Keywords? keywords = null, Level? level = null, DateTime? startTime = null, DateTime? endTime = null, string userId = null, int maxEvents = 0, int maxThreads = 8, List<long> eventRecordId = null, TimePeriod? timePeriod = null, CancellationToken cancellationToken = default) {
+    public static IAsyncEnumerable<EventObject> QueryLogsParallel(KnownLog logName, List<int>? eventIds = null, List<string?>? machineNames = null, string? providerName = null, Keywords? keywords = null, Level? level = null, DateTime? startTime = null, DateTime? endTime = null, string? userId = null, int maxEvents = 0, int maxThreads = 8, List<long>? eventRecordId = null, TimePeriod? timePeriod = null, CancellationToken cancellationToken = default) {
         return QueryLogsParallel(LogNameToString(logName), eventIds, machineNames, providerName, keywords, level, startTime, endTime, userId, maxEvents, maxThreads, eventRecordId, timePeriod, cancellationToken);
     }
 
-    public static Task<IEnumerable<EventObject>> QueryLogsParallelAsync(KnownLog logName, List<int> eventIds = null, List<string> machineNames = null, string providerName = null, Keywords? keywords = null, Level? level = null, DateTime? startTime = null, DateTime? endTime = null, string userId = null, int maxEvents = 0, int maxThreads = 8, List<long> eventRecordId = null, TimePeriod? timePeriod = null, CancellationToken cancellationToken = default) {
+    public static Task<IEnumerable<EventObject>> QueryLogsParallelAsync(KnownLog logName, List<int>? eventIds = null, List<string?>? machineNames = null, string? providerName = null, Keywords? keywords = null, Level? level = null, DateTime? startTime = null, DateTime? endTime = null, string? userId = null, int maxEvents = 0, int maxThreads = 8, List<long>? eventRecordId = null, TimePeriod? timePeriod = null, CancellationToken cancellationToken = default) {
         return QueryLogsParallelAsync(LogNameToString(logName), eventIds, machineNames, providerName, keywords, level, startTime, endTime, userId, maxEvents, maxThreads, eventRecordId, timePeriod, cancellationToken);
     }
 
-    private static Task CreateTask(string machineName, string logName, List<int> eventIds, string providerName, Keywords? keywords, Level? level, DateTime? startTime, DateTime? endTime, string userId, int maxEvents, SemaphoreSlim semaphore, BlockingCollection<EventObject> results, CancellationToken cancellationToken, List<long> eventRecordId = null, TimePeriod? timePeriod = null) {
+    private static Task CreateTask(string? machineName, string logName, List<int>? eventIds, string? providerName, Keywords? keywords, Level? level, DateTime? startTime, DateTime? endTime, string? userId, int maxEvents, SemaphoreSlim semaphore, BlockingCollection<EventObject> results, CancellationToken cancellationToken, List<long>? eventRecordId = null, TimePeriod? timePeriod = null) {
         return Task.Run(async () => {
             await semaphore.WaitAsync(cancellationToken);
             try {
@@ -91,7 +91,7 @@ public partial class SearchEvents : Settings {
         }, cancellationToken);
     }
 
-    public static IEnumerable<EventObject> QueryLogsParallelForEach(string logName, List<int> eventIds = null, List<string> machineNames = null, string providerName = null, Keywords? keywords = null, Level? level = null, DateTime? startTime = null, DateTime? endTime = null, string userId = null, int maxEvents = 0, int maxThreads = 4, List<long> eventRecordId = null, CancellationToken cancellationToken = default) {
+    public static IEnumerable<EventObject> QueryLogsParallelForEach(string logName, List<int>? eventIds = null, List<string?>? machineNames = null, string? providerName = null, Keywords? keywords = null, Level? level = null, DateTime? startTime = null, DateTime? endTime = null, string? userId = null, int maxEvents = 0, int maxThreads = 4, List<long>? eventRecordId = null, CancellationToken cancellationToken = default) {
         if (machineNames == null || !machineNames.Any()) {
             throw new ArgumentException("At least one machine name must be provided", nameof(machineNames));
         }
@@ -143,7 +143,7 @@ public partial class SearchEvents : Settings {
         }
     }
 
-    public static IEnumerable<EventObject> QueryLogsParallelForEach(KnownLog logName, List<int> eventIds = null, List<string> machineNames = null, string providerName = null, Keywords? keywords = null, Level? level = null, DateTime? startTime = null, DateTime? endTime = null, string userId = null, int maxEvents = 0, int maxThreads = 4, List<long> eventRecordId = null, CancellationToken cancellationToken = default) {
+    public static IEnumerable<EventObject> QueryLogsParallelForEach(KnownLog logName, List<int>? eventIds = null, List<string?>? machineNames = null, string? providerName = null, Keywords? keywords = null, Level? level = null, DateTime? startTime = null, DateTime? endTime = null, string? userId = null, int maxEvents = 0, int maxThreads = 4, List<long>? eventRecordId = null, CancellationToken cancellationToken = default) {
         return QueryLogsParallelForEach(LogNameToString(logName), eventIds, machineNames, providerName, keywords, level, startTime, endTime, userId, maxEvents, maxThreads, eventRecordId, cancellationToken);
     }
 }

--- a/Sources/EventViewerX/SearchEvents.QueryLog.cs
+++ b/Sources/EventViewerX/SearchEvents.QueryLog.cs
@@ -13,7 +13,7 @@ public partial class SearchEvents : Settings {
     /// Initialize the EventSearching class with an internal logger
     /// </summary>
     /// <param name="internalLogger">The internal logger.</param>
-    public SearchEvents(InternalLogger internalLogger = null) {
+    public SearchEvents(InternalLogger? internalLogger = null) {
         if (internalLogger != null) {
             _logger = internalLogger;
         }
@@ -25,24 +25,24 @@ public partial class SearchEvents : Settings {
     /// <param name="query">The query.</param>
     /// <param name="machineName">Name of the machine.</param>
     /// <returns>Initialized <see cref="EventLogReader"/> or null when failed.</returns>
-    private static EventLogReader CreateEventLogReader(EventLogQuery query, string machineName) {
+    private static EventLogReader CreateEventLogReader(EventLogQuery query, string? machineName) {
         string targetMachine = string.IsNullOrEmpty(machineName) ? GetFQDN() : machineName;
         if (query == null) {
             _logger.WriteWarning($"An error occurred on {targetMachine} while creating the event log reader: Query cannot be null.");
-            return null;
+            return null!;
         }
 
         try {
             return new EventLogReader(query);
         } catch (EventLogException ex) {
             _logger.WriteWarning($"An error occurred on {targetMachine} while creating the event log reader: {ex.Message}");
-            return null;
+            return null!;
         } catch (UnauthorizedAccessException ex) {
             _logger.WriteWarning($"Insufficient permissions to read the event log on {targetMachine}: {ex.Message}");
-            return null;
+            return null!;
         } catch (Exception ex) {
             _logger.WriteWarning($"An error occurred on {targetMachine} while creating the event log reader: {ex.Message}");
-            return null;
+            return null!;
         }
     }
 
@@ -57,7 +57,7 @@ public partial class SearchEvents : Settings {
     /// <param name="startTime">Optional start time to filter events from.</param>
     /// <param name="endTime">Optional end time to filter events until.</param>
     /// <param name="userId">Optional user ID to filter events by.</param>
-    private static IEnumerable<EventObject> QueryLogEnumerable(string logName, List<int> eventIds = null, string machineName = null, string providerName = null, Keywords? keywords = null, Level? level = null, DateTime? startTime = null, DateTime? endTime = null, string userId = null, int maxEvents = 0, List<long> eventRecordId = null, TimePeriod? timePeriod = null, CancellationToken cancellationToken = default) {
+    private static IEnumerable<EventObject> QueryLogEnumerable(string logName, List<int>? eventIds = null, string? machineName = null, string? providerName = null, Keywords? keywords = null, Level? level = null, DateTime? startTime = null, DateTime? endTime = null, string? userId = null, int maxEvents = 0, List<long>? eventRecordId = null, TimePeriod? timePeriod = null, CancellationToken cancellationToken = default) {
         if (eventIds != null && eventIds.Any(id => id <= 0)) {
             throw new ArgumentException("Event IDs must be positive.", nameof(eventIds));
         }
@@ -68,7 +68,7 @@ public partial class SearchEvents : Settings {
 
         string queryString = eventRecordId != null
             ? BuildQueryString(eventRecordId)
-            : BuildQueryString(logName, eventIds, providerName, keywords, level, startTime, endTime, userId, timePeriod: timePeriod);
+            : BuildQueryString(logName, eventIds, providerName, keywords, level, startTime, endTime, userId ?? string.Empty, timePeriod: timePeriod);
 
         _logger.WriteVerbose($"Querying log '{logName}' on '{machineName} with query: {queryString}");
 
@@ -111,11 +111,11 @@ public partial class SearchEvents : Settings {
     /// <param name="eventRecordId">The event record identifier.</param>
     /// <param name="timePeriod">The time period.</param>
     /// <returns>Enumerable collection of matching events.</returns>
-    public static IEnumerable<EventObject> QueryLog(string logName, List<int> eventIds = null, string machineName = null, string providerName = null, Keywords? keywords = null, Level? level = null, DateTime? startTime = null, DateTime? endTime = null, string userId = null, int maxEvents = 0, List<long> eventRecordId = null, TimePeriod? timePeriod = null, CancellationToken cancellationToken = default) {
+    public static IEnumerable<EventObject> QueryLog(string logName, List<int>? eventIds = null, string? machineName = null, string? providerName = null, Keywords? keywords = null, Level? level = null, DateTime? startTime = null, DateTime? endTime = null, string? userId = null, int maxEvents = 0, List<long>? eventRecordId = null, TimePeriod? timePeriod = null, CancellationToken cancellationToken = default) {
         return QueryLogEnumerable(logName, eventIds, machineName, providerName, keywords, level, startTime, endTime, userId, maxEvents, eventRecordId, timePeriod, cancellationToken);
     }
 
-    public static IEnumerable<EventObject> QueryLog(KnownLog logName, List<int> eventIds = null, string machineName = null, string providerName = null, Keywords? keywords = null, Level? level = null, DateTime? startTime = null, DateTime? endTime = null, string userId = null, int maxEvents = 0, List<long> eventRecordId = null, TimePeriod? timePeriod = null, CancellationToken cancellationToken = default) {
+    public static IEnumerable<EventObject> QueryLog(KnownLog logName, List<int>? eventIds = null, string? machineName = null, string? providerName = null, Keywords? keywords = null, Level? level = null, DateTime? startTime = null, DateTime? endTime = null, string? userId = null, int maxEvents = 0, List<long>? eventRecordId = null, TimePeriod? timePeriod = null, CancellationToken cancellationToken = default) {
         return QueryLog(LogNameToString(logName), eventIds, machineName, providerName, keywords, level, startTime, endTime, userId, maxEvents, eventRecordId, timePeriod, cancellationToken);
     }
 
@@ -155,7 +155,7 @@ public partial class SearchEvents : Settings {
     /// <param name="opcodes">The opcodes.</param>
     /// <param name="timePeriod">The time period.</param>
     /// <returns>XML query string.</returns>
-    private static string BuildQueryString(string logName, List<int> eventIds = null, string providerName = null, Keywords? keywords = null, Level? level = null, DateTime? startTime = null, DateTime? endTime = null, string userId = null, List<int> tasks = null, List<int> opcodes = null, TimePeriod? timePeriod = null) {
+    private static string BuildQueryString(string logName, List<int>? eventIds = null, string? providerName = null, Keywords? keywords = null, Level? level = null, DateTime? startTime = null, DateTime? endTime = null, string? userId = null, List<int>? tasks = null, List<int>? opcodes = null, TimePeriod? timePeriod = null) {
         TimeSpan? lastPeriod = null;
         if (timePeriod.HasValue) {
             var times = TimeHelper.GetTimePeriod(timePeriod.Value);

--- a/Sources/EventViewerX/SearchEvents.QueryNamedEvents.cs
+++ b/Sources/EventViewerX/SearchEvents.QueryNamedEvents.cs
@@ -24,7 +24,7 @@ namespace EventViewerX {
         /// <param name="maxEvents">Maximum events to return.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>Asynchronous sequence of simplified events.</returns>
-        public static async IAsyncEnumerable<EventObjectSlim> FindEventsByNamedEvents(List<NamedEvents> typeEventsList, List<string> machineNames = null, DateTime? startTime = null, DateTime? endTime = null, TimePeriod? timePeriod = null, int maxThreads = 8, int maxEvents = 0, [EnumeratorCancellation] CancellationToken cancellationToken = default) {
+        public static async IAsyncEnumerable<EventObjectSlim> FindEventsByNamedEvents(List<NamedEvents> typeEventsList, List<string?>? machineNames = null, DateTime? startTime = null, DateTime? endTime = null, TimePeriod? timePeriod = null, int maxThreads = 8, int maxEvents = 0, [EnumeratorCancellation] CancellationToken cancellationToken = default) {
             var eventInfoDict = EventObjectSlim.GetEventInfoForNamedEvents(typeEventsList);
 
             var semaphore = new SemaphoreSlim(maxThreads);

--- a/Sources/EventViewerX/SearchEvents.WinEventFilter.Method.cs
+++ b/Sources/EventViewerX/SearchEvents.WinEventFilter.Method.cs
@@ -88,8 +88,8 @@ public partial class SearchEvents {
             foreach (Hashtable table in namedDataFilter) {
                 var keyFilters = new List<string>();
                 foreach (var key in table.Keys) {
-                    var keyName = EscapeXPathValue(key.ToString());
-                    var values = AsEnumerable(table[key]);
+                    var keyName = EscapeXPathValue(key?.ToString() ?? string.Empty);
+                    var values = AsEnumerable(table[key!]);
                     if (values.Any()) {
                         keyFilters.Add(InitializeXPathFilter(values, $"Data[@Name='{keyName}'] = '{{0}}'", "{0}", "or", true));
                     } else {
@@ -105,8 +105,8 @@ public partial class SearchEvents {
             foreach (Hashtable table in namedDataExcludeFilter) {
                 var keyFilters = new List<string>();
                 foreach (var key in table.Keys) {
-                    var keyName = EscapeXPathValue(key.ToString());
-                    var values = AsEnumerable(table[key]);
+                    var keyName = EscapeXPathValue(key?.ToString() ?? string.Empty);
+                    var values = AsEnumerable(table[key!]);
                     if (values.Any()) {
                         keyFilters.Add(InitializeXPathFilter(values, $"Data[@Name='{keyName}'] != '{{0}}'", "{0}", "and", true));
                     } else {

--- a/Sources/EventViewerX/SearchEvents.WinEventFilter.cs
+++ b/Sources/EventViewerX/SearchEvents.WinEventFilter.cs
@@ -13,25 +13,28 @@ public partial class SearchEvents {
         return newFilter;
     }
 
-    private static string InitializeXPathFilter(IEnumerable<object> items, string forEachFormatString, string finalizeFormatString, string logic = "or", bool noParenthesis = false, bool escapeItems = true) {
+    private static string InitializeXPathFilter(IEnumerable<object?> items, string forEachFormatString, string finalizeFormatString, string logic = "or", bool noParenthesis = false, bool escapeItems = true) {
         var filter = string.Empty;
         foreach (var item in items) {
-            var value = escapeItems ? EscapeXPathValue(item.ToString()) : item.ToString();
+            if (item == null) {
+                continue;
+            }
+            var value = escapeItems ? EscapeXPathValue(item.ToString()!) : item.ToString();
             var formatted = forEachFormatString.Replace("{0}", $"{value}");
             filter = JoinXPathFilter(formatted, filter, logic, noParenthesis);
         }
         return finalizeFormatString.Replace("{0}", $"{filter}");
     }
 
-    private static IEnumerable<string> AsEnumerable(object obj) {
+    private static IEnumerable<string> AsEnumerable(object? obj) {
         if (obj is IEnumerable enumerable and not string) {
             foreach (var o in enumerable) {
                 if (o != null) {
-                    yield return o.ToString();
+                    yield return o.ToString()!;
                 }
             }
         } else if (obj != null) {
-            yield return obj.ToString();
+            yield return obj.ToString()!;
         }
     }
 

--- a/Sources/EventViewerX/SearchEvents.WinEventInformation.cs
+++ b/Sources/EventViewerX/SearchEvents.WinEventInformation.cs
@@ -12,7 +12,7 @@ namespace EventViewerX {
     public partial class SearchEvents : Settings {
         public static IEnumerable<WinEventInformation> GetWinEventInformation(string[]? logNames, List<string>? machines, List<string>? filePaths, int maxDegreeOfParallelism = 50) {
             if (machines == null || machines.Count == 0) {
-                machines = new List<string> { null };
+                machines = new List<string> { null! };
             }
 
             if (logNames != null && logNames.Length > 0) {
@@ -30,24 +30,24 @@ namespace EventViewerX {
 
         private static WinEventInformation ConvertLogDetails(EventLogDetails details) {
             var info = new WinEventInformation {
-                MachineName = details.MachineName,
-                LogName = details.LogName,
-                LogType = details.LogType,
+                MachineName = details.MachineName ?? string.Empty,
+                LogName = details.LogName ?? string.Empty,
+                LogType = details.LogType ?? string.Empty,
                 LogIsolation = details.LogIsolation,
                 IsEnabled = details.IsEnabled,
                 IsLogFull = details.IsLogFull,
                 MaximumSizeInBytes = details.MaximumSizeInBytes,
-                LogFilePath = details.LogFilePath,
-                LogMode = details.LogMode,
-                OwningProviderName = details.OwningProviderName,
-                ProviderNames = details.ProviderNames,
-                ProviderLevel = details.ProviderLevel,
-                ProviderKeywords = details.ProviderKeywords,
+                LogFilePath = details.LogFilePath ?? string.Empty,
+                LogMode = details.LogMode ?? string.Empty,
+                OwningProviderName = details.OwningProviderName ?? string.Empty,
+                ProviderNames = details.ProviderNames ?? new List<string>(),
+                ProviderLevel = details.ProviderLevel ?? string.Empty,
+                ProviderKeywords = details.ProviderKeywords ?? string.Empty,
                 ProviderBufferSize = details.ProviderBufferSize,
                 ProviderMinimumNumberOfBuffers = details.ProviderMinimumNumberOfBuffers,
                 ProviderMaximumNumberOfBuffers = details.ProviderMaximumNumberOfBuffers,
                 ProviderLatency = details.ProviderLatency,
-                ProviderControlGuid = details.ProviderControlGuid,
+                ProviderControlGuid = details.ProviderControlGuid ?? string.Empty,
                 CreationTime = details.CreationTime,
                 LastAccessTime = details.LastAccessTime,
                 LastWriteTime = details.LastWriteTime,
@@ -57,9 +57,9 @@ namespace EventViewerX {
                 FileSizeMaximumMB = details.FileSizeMaximumMB,
                 RecordCount = details.RecordCount,
                 OldestRecordNumber = details.OldestRecordNumber,
-                SecurityDescriptor = details.SecurityDescriptor,
+                SecurityDescriptor = details.SecurityDescriptor ?? string.Empty,
                 IsClassicLog = details.IsClassicLog,
-                Source = details.MachineName
+                Source = details.MachineName ?? string.Empty
             };
 
             // Map LogMode to human-readable EventAction
@@ -74,19 +74,19 @@ namespace EventViewerX {
             info.FileSizeMB = details.FileSizeCurrentMB;
             info.MaximumSizeMB = details.FileSizeMaximumMB;
 
-            info.ProviderNamesExpanded = string.Join(", ", details.ProviderNames);
+            info.ProviderNamesExpanded = string.Join(", ", details.ProviderNames ?? new List<string>());
             if (!string.IsNullOrEmpty(details.SecurityDescriptor)) {
                 try {
                     var sd = new CommonSecurityDescriptor(false, false, details.SecurityDescriptor);
-                    info.SecurityDescriptorOwner = sd.Owner?.ToString();
-                    info.SecurityDescriptorGroup = sd.Group?.ToString();
-                    info.SecurityDescriptorDiscretionaryAcl = sd.DiscretionaryAcl?.ToString();
-                    info.SecurityDescriptorSystemAcl = sd.SystemAcl?.ToString();
+                    info.SecurityDescriptorOwner = sd.Owner?.ToString() ?? string.Empty;
+                    info.SecurityDescriptorGroup = sd.Group?.ToString() ?? string.Empty;
+                    info.SecurityDescriptorDiscretionaryAcl = sd.DiscretionaryAcl?.ToString() ?? string.Empty;
+                    info.SecurityDescriptorSystemAcl = sd.SystemAcl?.ToString() ?? string.Empty;
                 } catch {
                 }
             }
-            info.EventOldest = GetEventTime(details.LogName, details.MachineName, false);
-            info.EventNewest = GetEventTime(details.LogName, details.MachineName, true);
+            info.EventOldest = GetEventTime(details.LogName ?? string.Empty, details.MachineName ?? string.Empty, false);
+            info.EventNewest = GetEventTime(details.LogName ?? string.Empty, details.MachineName ?? string.Empty, true);
             return info;
         }
 
@@ -160,7 +160,7 @@ namespace EventViewerX {
                 ProviderNames = new List<string>(),
                 ProviderNamesExpanded = string.Empty,
                 RecordCount = recordCount,
-                SecurityDescriptor = null,
+                SecurityDescriptor = string.Empty,
                 Source = "File"
             };
 

--- a/Sources/EventViewerX/SearchEvents.WriteEvent.Method.cs
+++ b/Sources/EventViewerX/SearchEvents.WriteEvent.Method.cs
@@ -4,7 +4,7 @@ using System.Linq;
 namespace EventViewerX;
 
 public partial class SearchEvents : Settings {
-    public static void WriteEvent(string source, string log, string message, EventLogEntryType type, int category, int eventId, string machineName, byte[] rawData, params string[] replacementStrings) {
+    public static void WriteEvent(string source, string log, string message, EventLogEntryType type, int category, int eventId, string? machineName, byte[]? rawData, params string[]? replacementStrings) {
         if (category is < short.MinValue or > short.MaxValue) {
             throw new ArgumentOutOfRangeException(nameof(category), category, $"Category must fit into Int16 range ({short.MinValue} - {short.MaxValue}).");
         }

--- a/Sources/EventViewerX/SearchEvents.WriteEvent.cs
+++ b/Sources/EventViewerX/SearchEvents.WriteEvent.cs
@@ -13,7 +13,7 @@ public partial class SearchEvents : Settings {
     /// <param name="eventId">The event identifier.</param>
     /// <param name="machineName">Name of the machine.</param>
     /// <param name="replacementStrings">The replacement strings.</param>
-    public static void WriteEvent(string source, string log, string message, EventLogEntryType type, int category, int eventId, string machineName, params string[] replacementStrings) {
+    public static void WriteEvent(string source, string log, string message, EventLogEntryType type, int category, int eventId, string? machineName, params string[]? replacementStrings) {
         WriteEvent(source, log, message, type, category, eventId, machineName, null, replacementStrings);
     }
 
@@ -27,7 +27,7 @@ public partial class SearchEvents : Settings {
     /// <param name="eventId"></param>
     /// <param name="machineName"></param>
     /// <param name="replacementStrings"></param>
-    public static void WriteEvent(string source, string log, string message, EventLogEntryType type, int eventId, string machineName, params string[] replacementStrings) {
+    public static void WriteEvent(string source, string log, string message, EventLogEntryType type, int eventId, string? machineName, params string[]? replacementStrings) {
         WriteEvent(source, log, message, type, 0, eventId, machineName, null, replacementStrings);
     }
 
@@ -52,7 +52,7 @@ public partial class SearchEvents : Settings {
     /// <param name="log">The log.</param>
     /// <param name="machineName">Name of the machine.</param>
     /// <returns><c>true</c> when source exists or is created.</returns>
-    public static bool CreateLogSource(string source, string log, string machineName = null) {
+    public static bool CreateLogSource(string source, string log, string? machineName = null) {
         try {
             if (string.IsNullOrEmpty(machineName)) {
                 if (!EventLog.SourceExists(source)) {

--- a/Sources/EventViewerX/WatchEvents.cs
+++ b/Sources/EventViewerX/WatchEvents.cs
@@ -30,28 +30,28 @@ namespace EventViewerX {
         /// <summary>
         /// Username of the account that enabled staging.
         /// </summary>
-        public string StagingEnabledBy { get; private set; }
+        public string? StagingEnabledBy { get; private set; }
 
         /// <summary>
         /// Action executed when an event matching the filter is detected.
         /// </summary>
-        private Action<EventObject> _eventAction;
+        private Action<EventObject>? _eventAction;
 
         /// <summary>
         /// Events keyed by record identifier
         /// </summary>
         readonly ConcurrentDictionary<long, EventObject> WatchedEvents = new ConcurrentDictionary<long, EventObject>();
 
-        private EventLogSession _eventLogSession;
-        private EventLogWatcher _eventLogWatcher;
+        private EventLogSession? _eventLogSession;
+        private EventLogWatcher? _eventLogWatcher;
 
-        private string _machineName;
+        private string? _machineName;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="WatchEvents"/> class.
         /// </summary>
         /// <param name="internalLogger">Optional logger for verbose output.</param>
-        public WatchEvents(InternalLogger internalLogger = null) {
+        public WatchEvents(InternalLogger? internalLogger = null) {
             if (internalLogger != null) {
                 _logger = internalLogger;
             }
@@ -67,7 +67,7 @@ namespace EventViewerX {
         /// <param name="cancellationToken">Cancellation token to stop watching.</param>
         /// <param name="staging">Whether to use staging mode.</param>
         /// <param name="enabledBy">Account that enabled staging.</param>
-        public void Watch(string machineName, string logName, List<int> eventId, Action<EventObject> eventAction = null, CancellationToken cancellationToken = default, bool staging = false, string enabledBy = null) {
+        public void Watch(string? machineName, string logName, List<int> eventId, Action<EventObject>? eventAction = null, CancellationToken cancellationToken = default, bool staging = false, string? enabledBy = null) {
             NumberOfEventsFound = 0;
             _eventsFound = 0;
             Dispose();
@@ -100,17 +100,17 @@ namespace EventViewerX {
                 _logger.WriteWarning("Failed to create event log subscription to Target Machine {0}. Verify network connectivity, firewall settings, permissions, etc. Continuing on to next DC if applicable...  ({1})", machineName, ex.Message.Trim());
             }
         }
-        private void DetectEventsLogCallback(object Object, EventRecordWrittenEventArgs Args) {
+        private void DetectEventsLogCallback(object? sender, EventRecordWrittenEventArgs args) {
             try {
-                if (Args.EventRecord == null) {
+                if (args.EventRecord == null) {
                     _logger.WriteWarning("Event log subscription callback was given invalid data. This shouldn't happen.");
                 }
             } catch (Exception ex) {
                 _logger.WriteWarning("Event log subscription callback threw: ({0})", ex.Message.Trim());
                 return;
             }
-            if (Args.EventRecord != null) {
-                var Event = Args.EventRecord;
+            if (args.EventRecord != null) {
+                var Event = args.EventRecord;
                 if (_watchEventId.Contains(Event.Id)) {
                     Interlocked.Increment(ref NumberOfEventsFound);
                     Interlocked.Increment(ref _eventsFound);

--- a/Sources/EventViewerX/WinEventInformation.cs
+++ b/Sources/EventViewerX/WinEventInformation.cs
@@ -8,16 +8,16 @@ namespace EventViewerX {
     /// </summary>
     public class WinEventInformation {
         /// <summary>Provider source of the log.</summary>
-        public string Source { get; set; }
+        public string Source { get; set; } = string.Empty;
 
         /// <summary>Name of the machine hosting the log.</summary>
-        public string MachineName { get; set; }
+        public string MachineName { get; set; } = string.Empty;
 
         /// <summary>Name of the log.</summary>
-        public string LogName { get; set; }
+        public string LogName { get; set; } = string.Empty;
 
         /// <summary>Type of the log such as Operational or Administrative.</summary>
-        public string LogType { get; set; }
+        public string LogType { get; set; } = string.Empty;
 
         /// <summary>Isolation level for the log.</summary>
         public EventLogIsolation LogIsolation { get; set; }
@@ -35,28 +35,28 @@ namespace EventViewerX {
         public long MaximumSizeInBytes { get; set; }
 
         /// <summary>Path to the log file.</summary>
-        public string LogFilePath { get; set; }
+        public string LogFilePath { get; set; } = string.Empty;
 
         /// <summary>Current log mode such as Circular or Retain.</summary>
-        public string LogMode { get; set; }
+        public string LogMode { get; set; } = string.Empty;
 
         /// <summary>Action performed on the log.</summary>
-        public string EventAction { get; set; }
+        public string EventAction { get; set; } = string.Empty;
 
         /// <summary>Name of the owning provider.</summary>
-        public string OwningProviderName { get; set; }
+        public string OwningProviderName { get; set; } = string.Empty;
 
         /// <summary>List of provider names for this log.</summary>
-        public List<string> ProviderNames { get; set; }
+        public List<string> ProviderNames { get; set; } = new();
 
         /// <summary>Expanded list of provider names as a string.</summary>
-        public string ProviderNamesExpanded { get; set; }
+        public string ProviderNamesExpanded { get; set; } = string.Empty;
 
         /// <summary>Provider level information.</summary>
-        public string ProviderLevel { get; set; }
+        public string ProviderLevel { get; set; } = string.Empty;
 
         /// <summary>Keywords configured on the provider.</summary>
-        public string ProviderKeywords { get; set; }
+        public string ProviderKeywords { get; set; } = string.Empty;
 
         /// <summary>Size of provider buffer.</summary>
         public int ProviderBufferSize { get; set; }
@@ -71,7 +71,7 @@ namespace EventViewerX {
         public int ProviderLatency { get; set; }
 
         /// <summary>Control GUID for the provider.</summary>
-        public string ProviderControlGuid { get; set; }
+        public string ProviderControlGuid { get; set; } = string.Empty;
 
         /// <summary>File creation time.</summary>
         public DateTime? CreationTime { get; set; }
@@ -107,19 +107,19 @@ namespace EventViewerX {
         public long? OldestRecordNumber { get; set; }
 
         /// <summary>Security descriptor of the log.</summary>
-        public string SecurityDescriptor { get; set; }
+        public string SecurityDescriptor { get; set; } = string.Empty;
 
         /// <summary>Owner from the security descriptor.</summary>
-        public string SecurityDescriptorOwner { get; set; }
+        public string SecurityDescriptorOwner { get; set; } = string.Empty;
 
         /// <summary>Group from the security descriptor.</summary>
-        public string SecurityDescriptorGroup { get; set; }
+        public string SecurityDescriptorGroup { get; set; } = string.Empty;
 
         /// <summary>DACL from the security descriptor.</summary>
-        public string SecurityDescriptorDiscretionaryAcl { get; set; }
+        public string SecurityDescriptorDiscretionaryAcl { get; set; } = string.Empty;
 
         /// <summary>SACL from the security descriptor.</summary>
-        public string SecurityDescriptorSystemAcl { get; set; }
+        public string SecurityDescriptorSystemAcl { get; set; } = string.Empty;
 
         /// <summary>Date of the newest event in the log.</summary>
         public DateTime? EventNewest { get; set; }


### PR DESCRIPTION
## Summary
- align event log APIs with nullable reference types and safer defaults
- initialize event metadata models and watchers to prevent null reference warnings
- harden XPath filter helpers against null items

## Testing
- `dotnet build Sources/EventViewerX/EventViewerX.csproj -p:TargetFrameworks="net8.0"`

------
https://chatgpt.com/codex/tasks/task_e_68a069ca8404832eb391cde42413c77e