### PR TITLE
refactor(windows): split client group policy rule classes

### DIFF
--- a/Sources/EventViewerX/Rules/Windows/ClientGroupPoliciesApplication.cs
+++ b/Sources/EventViewerX/Rules/Windows/ClientGroupPoliciesApplication.cs
@@ -1,0 +1,13 @@
+namespace EventViewerX.Rules.Windows;
+
+/// <summary>
+/// Client side group policy processing events from the Application log.
+/// </summary>
+public class ClientGroupPoliciesApplication : ClientGroupPoliciesBase {
+    public override List<int> EventIds => new() { 4098 };
+    public override string LogName => "Application";
+    public override NamedEvents NamedEvent => NamedEvents.ClientGroupPoliciesApplication;
+
+    public ClientGroupPoliciesApplication(EventObject eventObject) : base(eventObject) { }
+}
+

--- a/Sources/EventViewerX/Rules/Windows/ClientGroupPoliciesBase.cs
+++ b/Sources/EventViewerX/Rules/Windows/ClientGroupPoliciesBase.cs
@@ -32,24 +32,3 @@ public abstract class ClientGroupPoliciesBase : EventRuleBase {
     }
 }
 
-/// <summary>
-/// Client side group policy processing events from the Application log.
-/// </summary>
-public class ClientGroupPoliciesApplication : ClientGroupPoliciesBase {
-    public override List<int> EventIds => new() { 4098 };
-    public override string LogName => "Application";
-    public override NamedEvents NamedEvent => NamedEvents.ClientGroupPoliciesApplication;
-
-    public ClientGroupPoliciesApplication(EventObject eventObject) : base(eventObject) { }
-}
-
-/// <summary>
-/// Client side group policy processing events from the System log.
-/// </summary>
-public class ClientGroupPoliciesSystem : ClientGroupPoliciesBase {
-    public override List<int> EventIds => new() { 1085 };
-    public override string LogName => "System";
-    public override NamedEvents NamedEvent => NamedEvents.ClientGroupPoliciesSystem;
-
-    public ClientGroupPoliciesSystem(EventObject eventObject) : base(eventObject) { }
-}

--- a/Sources/EventViewerX/Rules/Windows/ClientGroupPoliciesSystem.cs
+++ b/Sources/EventViewerX/Rules/Windows/ClientGroupPoliciesSystem.cs
@@ -1,0 +1,13 @@
+namespace EventViewerX.Rules.Windows;
+
+/// <summary>
+/// Client side group policy processing events from the System log.
+/// </summary>
+public class ClientGroupPoliciesSystem : ClientGroupPoliciesBase {
+    public override List<int> EventIds => new() { 1085 };
+    public override string LogName => "System";
+    public override NamedEvents NamedEvent => NamedEvents.ClientGroupPoliciesSystem;
+
+    public ClientGroupPoliciesSystem(EventObject eventObject) : base(eventObject) { }
+}
+


### PR DESCRIPTION
## Summary
- split ClientGroupPolicies into base, application, and system-specific rule files

## Testing
- `dotnet build Sources/EventViewerX/EventViewerX.csproj -c Release` *(fails: NETSDK1045 The current .NET SDK does not support targeting .NET 9.0)*
- `dotnet test Sources/EventViewerX.Tests/EventViewerX.Tests.csproj -c Release` *(fails: NETSDK1045 The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a069a60294832e82892132b070df9b