### PR TITLE
feat(eventviewerx): expose event log detail diagnostics

### DIFF
--- a/Sources/EventViewerX.Tests/TestEventLogDetailsResult.cs
+++ b/Sources/EventViewerX.Tests/TestEventLogDetailsResult.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Diagnostics.Eventing.Reader;
+using Xunit;
+
+namespace EventViewerX.Tests;
+
+public class TestEventLogDetailsResult {
+    [Fact]
+    public void GetLogDetailsResult_KnownLog_ReturnsDetails() {
+        if (!OperatingSystem.IsWindows()) return;
+
+        EventLogDetailsResult result = SearchEvents.GetLogDetailsResult("Application");
+
+        Assert.True(result.Success);
+        Assert.Equal(EventLogDetailsStatus.Success, result.Status);
+        Assert.NotNull(result.Details);
+        Assert.Equal("Application", result.LogName);
+    }
+
+    [Fact]
+    public void GetLogDetailsResult_MissingLog_ReturnsDiagnosticFailure() {
+        if (!OperatingSystem.IsWindows()) return;
+
+        EventLogDetailsResult result = SearchEvents.GetLogDetailsResult("Definitely-Missing-EventViewerX-UnitTest-Log");
+
+        Assert.False(result.Success);
+        Assert.Equal(EventLogDetailsStatus.LogConfigurationUnavailable, result.Status);
+        Assert.Equal("Definitely-Missing-EventViewerX-UnitTest-Log", result.LogName);
+        Assert.False(string.IsNullOrWhiteSpace(result.ErrorType));
+    }
+
+    [Fact]
+    public void GetLogDetailsResult_ExistingSession_ReusesSession() {
+        if (!OperatingSystem.IsWindows()) return;
+
+        using var session = new EventLogSession();
+
+        EventLogDetailsResult result = SearchEvents.GetLogDetailsResult("Application", session, machineName: Environment.MachineName);
+
+        Assert.True(result.Success);
+        Assert.Equal(EventLogDetailsStatus.Success, result.Status);
+        Assert.NotNull(result.Details);
+        Assert.Equal(Environment.MachineName, result.MachineName);
+    }
+
+    [Fact]
+    public void OpenSessionResult_LocalMachine_ReturnsSession() {
+        if (!OperatingSystem.IsWindows()) return;
+
+        using EventLogSessionOpenResult result = SearchEvents.OpenSessionResult(null, purpose: "UnitTest", logName: "Application");
+
+        Assert.True(result.Success);
+        Assert.Equal(EventLogSessionOpenStatus.Success, result.Status);
+        Assert.NotNull(result.Session);
+        Assert.Equal("UnitTest", result.Purpose);
+        Assert.Equal("Application", result.LogName);
+    }
+}

--- a/Sources/EventViewerX.Tests/TestLimitLog.cs
+++ b/Sources/EventViewerX.Tests/TestLimitLog.cs
@@ -8,34 +8,46 @@ public class TestLimitLog {
     public void LimitExistingLog() {
         if (!OperatingSystem.IsWindows()) return;
         if (!TestEnv.IsAdmin()) return;
-        const string logName = "EVXLimitTestLog";
+        string logName = "EVXLimitTestLog" + Guid.NewGuid().ToString("N");
         if (SearchEvents.LogExists(logName)) {
             SearchEvents.RemoveLog(logName);
         }
-        if (!SearchEvents.CreateLog(logName, logName, null, 1024, OverflowAction.OverwriteAsNeeded, 1)) return;
-        bool limited = SearchEvents.LimitLog(logName, null, 2048, OverflowAction.OverwriteOlder, 2);
-        if (!limited) return;
-        using EventLog log = new(logName);
-        Assert.Equal(2048, log.MaximumKilobytes);
-        Assert.Equal(OverflowAction.OverwriteOlder, log.OverflowAction);
-        Assert.Equal(2, log.MinimumRetentionDays);
-        SearchEvents.RemoveLog(logName);
+        try {
+            if (!SearchEvents.CreateLog(logName, logName, null, 1024, OverflowAction.OverwriteAsNeeded, 1)) return;
+            bool limited = SearchEvents.LimitLog(logName, null, 2048, OverflowAction.OverwriteOlder, 2);
+            if (!limited) return;
+            using EventLog log = new(logName);
+            Assert.Equal(2048, log.MaximumKilobytes);
+            Assert.Equal(OverflowAction.OverwriteOlder, log.OverflowAction);
+            Assert.Equal(2, log.MinimumRetentionDays);
+        }
+        finally {
+            if (SearchEvents.LogExists(logName)) {
+                SearchEvents.RemoveLog(logName);
+            }
+        }
     }
 
     [Fact]
     public void LimitLogOverwriteAsNeeded() {
         if (!OperatingSystem.IsWindows()) return;
         if (!TestEnv.IsAdmin()) return;
-        const string logName = "EVXLimitTestLog";
+        string logName = "EVXLimitTestLog" + Guid.NewGuid().ToString("N");
         if (SearchEvents.LogExists(logName)) {
             SearchEvents.RemoveLog(logName);
         }
-        if (!SearchEvents.CreateLog(logName, logName, null, 1024, OverflowAction.OverwriteAsNeeded, 1)) return;
-        bool limited = SearchEvents.LimitLog(logName, null, 4096, OverflowAction.OverwriteAsNeeded);
-        if (!limited) return;
-        using EventLog log = new(logName);
-        Assert.Equal(4096, log.MaximumKilobytes);
-        Assert.Equal(OverflowAction.OverwriteAsNeeded, log.OverflowAction);
-        SearchEvents.RemoveLog(logName);
+        try {
+            if (!SearchEvents.CreateLog(logName, logName, null, 1024, OverflowAction.OverwriteAsNeeded, 1)) return;
+            bool limited = SearchEvents.LimitLog(logName, null, 4096, OverflowAction.OverwriteAsNeeded);
+            if (!limited) return;
+            using EventLog log = new(logName);
+            Assert.Equal(4096, log.MaximumKilobytes);
+            Assert.Equal(OverflowAction.OverwriteAsNeeded, log.OverflowAction);
+        }
+        finally {
+            if (SearchEvents.LogExists(logName)) {
+                SearchEvents.RemoveLog(logName);
+            }
+        }
     }
 }

--- a/Sources/EventViewerX.Tests/TestLogManagement.cs
+++ b/Sources/EventViewerX.Tests/TestLogManagement.cs
@@ -27,17 +27,24 @@ public class TestLogManagement {
         if (!OperatingSystem.IsWindows()) return;
         if (!TestEnv.IsAdmin()) return;
 
-        const string logName = "EVXTestCustomLog";
+        string logName = "EVXTestCustomLog" + Guid.NewGuid().ToString("N");
         if (SearchEvents.LogExists(logName)) {
             SearchEvents.RemoveLog(logName);
         }
 
-        bool created = SearchEvents.CreateLog(logName, logName, null, 256, OverflowAction.OverwriteAsNeeded, 1);
-        if (!created) return; // environments without rights skip
-        Assert.True(SearchEvents.LogExists(logName));
+        try {
+            bool created = SearchEvents.CreateLog(logName, logName, null, 256, OverflowAction.OverwriteAsNeeded, 1);
+            if (!created) return; // environments without rights skip
+            Assert.True(SearchEvents.LogExists(logName));
 
-        bool removed = SearchEvents.RemoveLog(logName);
-        Assert.True(removed);
-        Assert.False(SearchEvents.LogExists(logName));
+            bool removed = SearchEvents.RemoveLog(logName);
+            Assert.True(removed);
+            Assert.False(SearchEvents.LogExists(logName));
+        }
+        finally {
+            if (SearchEvents.LogExists(logName)) {
+                SearchEvents.RemoveLog(logName);
+            }
+        }
     }
 }

--- a/Sources/EventViewerX/EventViewerX.csproj
+++ b/Sources/EventViewerX/EventViewerX.csproj
@@ -5,7 +5,7 @@
         <Description>Library to work with Event Logs</Description>
         <AssemblyName>EventViewerX</AssemblyName>
         <AssemblyTitle>EventViewerX</AssemblyTitle>
-        <VersionPrefix>3.3.3</VersionPrefix>
+        <VersionPrefix>3.3.4</VersionPrefix>
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <Company>Evotec</Company>

--- a/Sources/EventViewerX/Models/EventLogDetailsResult.cs
+++ b/Sources/EventViewerX/Models/EventLogDetailsResult.cs
@@ -1,0 +1,48 @@
+namespace EventViewerX;
+
+/// <summary>
+/// Status returned when querying event log details.
+/// </summary>
+public enum EventLogDetailsStatus {
+    /// <summary>Event log details were collected successfully.</summary>
+    Success,
+    /// <summary>The query exceeded the caller-provided timeout.</summary>
+    Timeout,
+    /// <summary>An EventLogSession could not be opened for the target host.</summary>
+    SessionUnavailable,
+    /// <summary>The target event log channel could not be opened or does not exist.</summary>
+    LogConfigurationUnavailable,
+    /// <summary>The event log configuration was collected but runtime log information was unavailable.</summary>
+    LogInformationUnavailable,
+    /// <summary>An unexpected error occurred while collecting event log details.</summary>
+    Error
+}
+
+/// <summary>
+/// Result of querying event log details, including diagnostic status when details are unavailable.
+/// </summary>
+public sealed class EventLogDetailsResult {
+    /// <summary>Event log channel name that was queried.</summary>
+    public string LogName { get; set; } = string.Empty;
+
+    /// <summary>Machine name used for the query.</summary>
+    public string? MachineName { get; set; }
+
+    /// <summary>Query status.</summary>
+    public EventLogDetailsStatus Status { get; set; }
+
+    /// <summary>True when details were collected successfully or partial details are available.</summary>
+    public bool Success => Status == EventLogDetailsStatus.Success || Details != null;
+
+    /// <summary>Collected event log details when available.</summary>
+    public EventLogDetails? Details { get; set; }
+
+    /// <summary>Diagnostic message when the query did not fully succeed.</summary>
+    public string ErrorMessage { get; set; } = string.Empty;
+
+    /// <summary>Underlying exception type when available.</summary>
+    public string ErrorType { get; set; } = string.Empty;
+
+    /// <summary>Timeout budget used for the query, in milliseconds.</summary>
+    public int TimeoutMs { get; set; }
+}

--- a/Sources/EventViewerX/Models/EventLogSessionOpenResult.cs
+++ b/Sources/EventViewerX/Models/EventLogSessionOpenResult.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Diagnostics.Eventing.Reader;
+
+namespace EventViewerX;
+
+/// <summary>
+/// Status returned when opening a Windows Event Log session.
+/// </summary>
+public enum EventLogSessionOpenStatus {
+    /// <summary>The Event Log session was opened successfully.</summary>
+    Success,
+    /// <summary>The local Event Log session could not be opened.</summary>
+    LocalSessionUnavailable,
+    /// <summary>The host was skipped because it is temporarily cached as unreachable.</summary>
+    NegativeCache,
+    /// <summary>The host did not answer the reachability probe.</summary>
+    PingFailed,
+    /// <summary>The Event Log RPC endpoint preflight did not succeed.</summary>
+    RpcUnavailable,
+    /// <summary>The Event Log session open attempt exceeded the timeout budget.</summary>
+    Timeout,
+    /// <summary>The Event Log session constructor failed.</summary>
+    EventLogSessionUnavailable,
+    /// <summary>An unexpected error occurred while opening the Event Log session.</summary>
+    Error
+}
+
+/// <summary>
+/// Result of opening a Windows Event Log session, including diagnostics for failure cases.
+/// </summary>
+public sealed class EventLogSessionOpenResult : IDisposable {
+    /// <summary>Input machine name used for the session request.</summary>
+    public string? MachineName { get; set; }
+
+    /// <summary>Resolved target host used for reachability checks.</summary>
+    public string TargetHost { get; set; } = string.Empty;
+
+    /// <summary>Logical caller or operation name.</summary>
+    public string Purpose { get; set; } = string.Empty;
+
+    /// <summary>Event log channel associated with the session request.</summary>
+    public string LogName { get; set; } = string.Empty;
+
+    /// <summary>Session open status.</summary>
+    public EventLogSessionOpenStatus Status { get; set; }
+
+    /// <summary>True when the session was opened successfully.</summary>
+    public bool Success => Status == EventLogSessionOpenStatus.Success && Session != null;
+
+    /// <summary>Opened Event Log session when successful.</summary>
+    public EventLogSession? Session { get; set; }
+
+    /// <summary>Diagnostic message when opening the session did not succeed.</summary>
+    public string ErrorMessage { get; set; } = string.Empty;
+
+    /// <summary>Underlying exception or diagnostic type when available.</summary>
+    public string ErrorType { get; set; } = string.Empty;
+
+    /// <summary>Timeout budget used for the session open attempt, in milliseconds.</summary>
+    public int TimeoutMs { get; set; }
+
+    /// <summary>UTC timestamp until which the target is cached as unreachable.</summary>
+    public DateTime? CachedUntilUtc { get; set; }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        Session?.Dispose();
+        Session = null;
+    }
+}

--- a/Sources/EventViewerX/SearchEvents.LogDetails.cs
+++ b/Sources/EventViewerX/SearchEvents.LogDetails.cs
@@ -9,6 +9,7 @@ namespace EventViewerX;
 /// Helper methods for retrieving event log configuration details.
 /// </summary>
 public partial class SearchEvents : Settings {
+    private const int DiagnosticTimeoutGraceMs = 500;
 
     /// <summary>
     /// Returns details for a single log without enumerating all logs. Time‑bounded to avoid hangs on large/remote channels.
@@ -16,12 +17,23 @@ public partial class SearchEvents : Settings {
     public static EventLogDetails? GetLogDetails(string logName, string? machineName = null, int timeoutMs = 3000) {
         if (string.IsNullOrWhiteSpace(logName)) throw new ArgumentException("logName cannot be null or empty", nameof(logName));
 
+        return GetLogDetailsResult(logName, machineName, timeoutMs).Details;
+    }
+
+    /// <summary>
+    /// Returns details for a single log with diagnostic status when the log cannot be read.
+    /// </summary>
+    public static EventLogDetailsResult GetLogDetailsResult(string logName, string? machineName = null, int timeoutMs = 3000) {
+        if (string.IsNullOrWhiteSpace(logName)) throw new ArgumentException("logName cannot be null or empty", nameof(logName));
+
         try {
-            Task<EventLogDetails?> task = Task.Run(() => SafeGet(logName, machineName, timeoutMs));
-            Task completed = Task.WhenAny(task, Task.Delay(timeoutMs)).GetAwaiter().GetResult();
-            return completed == task ? task.GetAwaiter().GetResult() : null;
-        } catch {
-            return null;
+            Task<EventLogDetailsResult> task = Task.Run(() => SafeGetResult(logName, machineName, timeoutMs));
+            Task completed = Task.WhenAny(task, Task.Delay(OuterTimeoutMs(timeoutMs))).GetAwaiter().GetResult();
+            return completed == task
+                ? task.GetAwaiter().GetResult()
+                : Failure(logName, machineName, EventLogDetailsStatus.Timeout, $"Timed out reading event log details after {timeoutMs} ms.", timeoutMs, "LogDetailsTimeout");
+        } catch (Exception ex) {
+            return Failure(logName, machineName, EventLogDetailsStatus.Error, ex.Message, timeoutMs, ex.GetType().Name);
         }
     }
 
@@ -33,53 +45,63 @@ public partial class SearchEvents : Settings {
         if (session == null) throw new ArgumentNullException(nameof(session));
         if (string.IsNullOrWhiteSpace(logName)) throw new ArgumentException("logName cannot be null or empty", nameof(logName));
 
+        return GetLogDetailsResult(logName, session, timeoutMs, machineName).Details;
+    }
+
+    /// <summary>
+    /// Reuses an existing EventLogSession (caller owns it) and returns diagnostic status when the log cannot be read.
+    /// </summary>
+    public static EventLogDetailsResult GetLogDetailsResult(string logName, EventLogSession session, int timeoutMs = 3000, string? machineName = null)
+    {
+        if (session == null) throw new ArgumentNullException(nameof(session));
+        if (string.IsNullOrWhiteSpace(logName)) throw new ArgumentException("logName cannot be null or empty", nameof(logName));
+
         try
         {
-            Task<EventLogDetails?> task = Task.Run(() => SafeGet(logName, session, timeoutMs, machineName));
-            Task completed = Task.WhenAny(task, Task.Delay(timeoutMs)).GetAwaiter().GetResult();
-            return completed == task ? task.GetAwaiter().GetResult() : null;
+            Task<EventLogDetailsResult> task = Task.Run(() => SafeGetResult(logName, session, timeoutMs, machineName));
+            Task completed = Task.WhenAny(task, Task.Delay(OuterTimeoutMs(timeoutMs))).GetAwaiter().GetResult();
+            return completed == task
+                ? task.GetAwaiter().GetResult()
+                : Failure(logName, machineName, EventLogDetailsStatus.Timeout, $"Timed out reading event log details after {timeoutMs} ms.", timeoutMs, "LogDetailsTimeout");
         }
-        catch
+        catch (Exception ex)
         {
-            return null;
+            return Failure(logName, machineName, EventLogDetailsStatus.Error, ex.Message, timeoutMs, ex.GetType().Name);
         }
     }
 
-    private static EventLogDetails? SafeGet(string logName, string? machineName, int timeoutMs) {
-        EventLogSession? session = null;
+    private static EventLogDetailsResult SafeGetResult(string logName, string? machineName, int timeoutMs) {
+        EventLogSessionOpenResult? sessionResult = null;
         try {
-            session = CreateSession(machineName, "LogDetails", logName, timeoutMs);
-            if (session == null) return null;
-
-            EventLogConfiguration? logConfig = null;
-            EventLogInformation? logInfoObj = null;
-
-            try {
-                logConfig = new EventLogConfiguration(logName, session);
-            } catch (EventLogException ex) {
-                _logger.WriteWarning($"Couldn't create EventLogConfiguration for {logName} on {machineName ?? GetFQDN()}: {ex.Message}");
+            sessionResult = CreateSessionResult(machineName, "LogDetails", logName, timeoutMs);
+            if (!sessionResult.Success || sessionResult.Session == null) {
+                return Failure(
+                    logName,
+                    machineName,
+                    EventLogDetailsStatus.SessionUnavailable,
+                    string.IsNullOrWhiteSpace(sessionResult.ErrorMessage)
+                        ? "Event log session could not be opened. Check host reachability, RPC/firewall access, Remote Event Log Management, and permissions."
+                        : sessionResult.ErrorMessage,
+                    timeoutMs,
+                    string.IsNullOrWhiteSpace(sessionResult.ErrorType)
+                        ? sessionResult.Status.ToString()
+                        : sessionResult.ErrorType);
             }
 
-            try {
-                logInfoObj = session.GetLogInformation(logName, PathType.LogName);
-            } catch (Exception ex) {
-                _logger.WriteVerbose($"Couldn't get log information for {logName} on {machineName ?? GetFQDN()}: {ex.Message}");
-            }
-
-            if (logConfig == null) return null;
-            return new EventLogDetails(_logger, machineName ?? GetFQDN(), logConfig, logInfoObj);
+            return SafeGetResult(logName, sessionResult.Session, timeoutMs, machineName);
         }
         finally {
-            session?.Dispose();
+            sessionResult?.Dispose();
         }
     }
 
-    private static EventLogDetails? SafeGet(string logName, EventLogSession session, int timeoutMs, string? machineName)
+    private static EventLogDetailsResult SafeGetResult(string logName, EventLogSession session, int timeoutMs, string? machineName)
     {
         try
         {
             EventLogConfiguration? logConfig = null;
             EventLogInformation? logInfoObj = null;
+            string hostName = machineName ?? GetFQDN();
 
             try
             {
@@ -87,7 +109,13 @@ public partial class SearchEvents : Settings {
             }
             catch (EventLogException ex)
             {
-                _logger.WriteWarning($"Couldn't create EventLogConfiguration for {logName} on {(machineName ?? GetFQDN())}: {ex.Message}");
+                _logger.WriteWarning($"Couldn't create EventLogConfiguration for {logName} on {hostName}: {ex.Message}");
+                return Failure(logName, machineName, EventLogDetailsStatus.LogConfigurationUnavailable, ex.Message, timeoutMs, ex.GetType().Name);
+            }
+            catch (Exception ex)
+            {
+                _logger.WriteWarning($"Couldn't create EventLogConfiguration for {logName} on {hostName}: {ex.Message}");
+                return Failure(logName, machineName, EventLogDetailsStatus.LogConfigurationUnavailable, ex.Message, timeoutMs, ex.GetType().Name);
             }
 
             try
@@ -96,17 +124,57 @@ public partial class SearchEvents : Settings {
             }
             catch (Exception ex)
             {
-                _logger.WriteVerbose($"Couldn't get log information for {logName} on {(machineName ?? GetFQDN())}: {ex.Message}");
+                _logger.WriteVerbose($"Couldn't get log information for {logName} on {hostName}: {ex.Message}");
             }
 
-            if (logConfig == null) return null;
-            return new EventLogDetails(_logger, machineName ?? GetFQDN(), logConfig, logInfoObj);
+            var details = new EventLogDetails(_logger, hostName, logConfig, logInfoObj);
+            if (logInfoObj == null)
+            {
+                return new EventLogDetailsResult
+                {
+                    LogName = logName,
+                    MachineName = hostName,
+                    Status = EventLogDetailsStatus.LogInformationUnavailable,
+                    Details = details,
+                    ErrorMessage = "Event log configuration was collected, but runtime log information was unavailable.",
+                    TimeoutMs = timeoutMs
+                };
+            }
+
+            return new EventLogDetailsResult
+            {
+                LogName = logName,
+                MachineName = hostName,
+                Status = EventLogDetailsStatus.Success,
+                Details = details,
+                TimeoutMs = timeoutMs
+            };
         }
-        finally
+        catch (Exception ex)
         {
-            // session lifetime owned by caller
+            return Failure(logName, machineName, EventLogDetailsStatus.Error, ex.Message, timeoutMs, ex.GetType().Name);
         }
     }
+
+    private static EventLogDetailsResult Failure(
+        string logName,
+        string? machineName,
+        EventLogDetailsStatus status,
+        string errorMessage,
+        int timeoutMs,
+        string? errorType = null) =>
+        new()
+        {
+            LogName = logName,
+            MachineName = machineName,
+            Status = status,
+            ErrorMessage = errorMessage,
+            ErrorType = errorType ?? string.Empty,
+            TimeoutMs = timeoutMs
+        };
+
+    private static int OuterTimeoutMs(int timeoutMs) =>
+        Math.Max(timeoutMs, 1) + DiagnosticTimeoutGraceMs;
 
     /// <summary>
     /// Enumerates event logs on the specified machine and returns their configuration details.

--- a/Sources/EventViewerX/SearchEvents.Session.cs
+++ b/Sources/EventViewerX/SearchEvents.Session.cs
@@ -24,25 +24,52 @@ public partial class SearchEvents : Settings
     /// </summary>
     internal static EventLogSession? CreateSession(string? machineName, string? purpose, string? logName, int? timeoutMs = null)
     {
+        return CreateSessionResult(machineName, purpose, logName, timeoutMs).Session;
+    }
+
+    internal static EventLogSessionOpenResult CreateSessionResult(string? machineName, string? purpose, string? logName, int? timeoutMs = null)
+    {
         int budget = Math.Max(1000, timeoutMs ?? DefaultSessionTimeoutMs);
+        string operation = purpose ?? "Session";
+        string channel = logName ?? string.Empty;
 
         // Local is fast; avoid ping/RPC probes (many CI agents block 135)
         if (IsLocalMachine(machineName))
         {
-            try { return new EventLogSession(); }
+            try
+            {
+                return SessionSuccess(machineName, GetFQDN(), operation, channel, budget, new EventLogSession());
+            }
             catch (Exception ex)
             {
-                _logger.WriteWarning($"{purpose ?? "Session"}: failed to open local session for '{logName}': {ex.Message}");
-                return null;
+                _logger.WriteWarning($"{operation}: failed to open local session for '{channel}': {ex.Message}");
+                return SessionFailure(
+                    machineName,
+                    GetFQDN(),
+                    operation,
+                    channel,
+                    EventLogSessionOpenStatus.LocalSessionUnavailable,
+                    $"Failed to open local Event Log session for '{channel}': {ex.Message}",
+                    budget,
+                    ex.GetType().Name);
             }
         }
 
         var normalizedHost = machineName?.Trim() ?? string.Empty;
         var targetHost = string.IsNullOrWhiteSpace(normalizedHost) ? GetFQDN() : normalizedHost;
-        if (IsHostNegativeCached(normalizedHost))
+        if (TryGetHostNegativeCacheExpiry(normalizedHost, out DateTime cachedUntilUtc))
         {
-            _logger.WriteVerbose($"{purpose ?? "Session"}: skipping {normalizedHost} (cached unreachable)");
-            return null;
+            _logger.WriteVerbose($"{operation}: skipping {normalizedHost} (cached unreachable)");
+            return SessionFailure(
+                machineName,
+                targetHost,
+                operation,
+                channel,
+                EventLogSessionOpenStatus.NegativeCache,
+                $"Host '{targetHost}' is temporarily cached as unreachable until {cachedUntilUtc:u}.",
+                budget,
+                nameof(EventLogSessionOpenStatus.NegativeCache),
+                cachedUntilUtc);
         }
 
         // Quick reachability check (ping) to fail fast on dead hosts
@@ -52,23 +79,44 @@ public partial class SearchEvents : Settings
             var reply = ping.Send(targetHost, Math.Min(DefaultPingTimeoutMs, budget));
             if (reply == null || reply.Status != System.Net.NetworkInformation.IPStatus.Success)
             {
-                _logger.WriteWarning($"{purpose ?? "Session"}: ping failed for '{targetHost}' when opening '{logName}'. Skipping.");
+                string pingStatus = reply?.Status.ToString() ?? "NoReply";
+                _logger.WriteWarning($"{operation}: ping failed for '{targetHost}' when opening '{channel}'. Skipping.");
                 MarkHostUnreachable(targetHost);
-                return null;
+                TryGetHostNegativeCacheExpiry(targetHost, out DateTime pingCachedUntilUtc);
+                return SessionFailure(
+                    machineName,
+                    targetHost,
+                    operation,
+                    channel,
+                    EventLogSessionOpenStatus.PingFailed,
+                    $"Ping probe failed for '{targetHost}' with status '{pingStatus}'.",
+                    budget,
+                    nameof(EventLogSessionOpenStatus.PingFailed),
+                    pingCachedUntilUtc);
             }
         }
         catch (Exception ex)
         {
             string reason = ex.InnerException?.Message ?? ex.Message;
-            _logger.WriteVerbose($"{purpose ?? "Session"}: ping probe failed for '{machineName}': {reason}. Continuing to session attempt.");
+            _logger.WriteVerbose($"{operation}: ping probe failed for '{machineName}': {reason}. Continuing to session attempt.");
         }
 
         // RPC (135) preflight to avoid EventLogSession hangs on dead/filtered hosts
         if (!RpcProbe(normalizedHost, Math.Min(DefaultRpcProbeTimeoutMs, budget)))
         {
-            _logger.WriteVerbose($"{purpose ?? "Session"}: RPC preflight failed for '{machineName}'");
+            _logger.WriteVerbose($"{operation}: RPC preflight failed for '{machineName}'");
             MarkHostUnreachable(normalizedHost);
-            return null;
+            TryGetHostNegativeCacheExpiry(normalizedHost, out DateTime rpcCachedUntilUtc);
+            return SessionFailure(
+                machineName,
+                targetHost,
+                operation,
+                channel,
+                EventLogSessionOpenStatus.RpcUnavailable,
+                $"RPC preflight to '{targetHost}' on port {Settings.RpcProbePort} failed.",
+                budget,
+                nameof(EventLogSessionOpenStatus.RpcUnavailable),
+                rpcCachedUntilUtc);
         }
 
         try
@@ -78,7 +126,7 @@ public partial class SearchEvents : Settings
             var completed = Task.WhenAny(task, Task.Delay(budget, cts.Token)).GetAwaiter().GetResult();
             if (completed != task)
             {
-                _logger.WriteWarning($"{purpose ?? "Session"}: timeout opening session to '{machineName}' for '{logName}' after {budget} ms");
+                _logger.WriteWarning($"{operation}: timeout opening session to '{machineName}' for '{channel}' after {budget} ms");
                 MarkHostUnreachable(normalizedHost);
 
                 // Ensure the late session (if it eventually opens) gets disposed.
@@ -89,23 +137,53 @@ public partial class SearchEvents : Settings
                         t.Result.Dispose();
                     }
                 }, TaskContinuationOptions.OnlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously);
-                return null;
+                TryGetHostNegativeCacheExpiry(normalizedHost, out DateTime timeoutCachedUntilUtc);
+                return SessionFailure(
+                    machineName,
+                    targetHost,
+                    operation,
+                    channel,
+                    EventLogSessionOpenStatus.Timeout,
+                    $"Timed out opening Event Log session to '{targetHost}' for '{channel}' after {budget} ms.",
+                    budget,
+                    nameof(EventLogSessionOpenStatus.Timeout),
+                    timeoutCachedUntilUtc);
             }
             // Success: clear any stale negative entry
             ClearNegativeCache(normalizedHost);
-            return task.GetAwaiter().GetResult();
+            return SessionSuccess(machineName, targetHost, operation, channel, budget, task.GetAwaiter().GetResult());
         }
         catch (EventLogException ex)
         {
-            _logger.WriteWarning($"{purpose ?? "Session"}: failed opening session to '{machineName}' for '{logName}': {ex.Message}");
+            _logger.WriteWarning($"{operation}: failed opening session to '{machineName}' for '{channel}': {ex.Message}");
             MarkHostUnreachable(normalizedHost);
-            return null;
+            TryGetHostNegativeCacheExpiry(normalizedHost, out DateTime exceptionCachedUntilUtc);
+            return SessionFailure(
+                machineName,
+                targetHost,
+                operation,
+                channel,
+                EventLogSessionOpenStatus.EventLogSessionUnavailable,
+                ex.Message,
+                budget,
+                ex.GetType().Name,
+                exceptionCachedUntilUtc);
         }
         catch (Exception ex)
         {
-            _logger.WriteWarning($"{purpose ?? "Session"}: unexpected error opening session to '{machineName}' for '{logName}': {ex.Message}");
+            _logger.WriteWarning($"{operation}: unexpected error opening session to '{machineName}' for '{channel}': {ex.Message}");
             MarkHostUnreachable(normalizedHost);
-            return null;
+            TryGetHostNegativeCacheExpiry(normalizedHost, out DateTime errorCachedUntilUtc);
+            return SessionFailure(
+                machineName,
+                targetHost,
+                operation,
+                channel,
+                EventLogSessionOpenStatus.Error,
+                ex.Message,
+                budget,
+                ex.GetType().Name,
+                errorCachedUntilUtc);
         }
     }
 
@@ -115,6 +193,14 @@ public partial class SearchEvents : Settings
     public static EventLogSession? OpenSession(string? machineName, int? timeoutMs = null, string? purpose = null, string? logName = null)
     {
         return CreateSession(machineName, purpose, logName, timeoutMs);
+    }
+
+    /// <summary>
+    /// Opens an Event Log session and returns diagnostic details when the session cannot be created.
+    /// </summary>
+    public static EventLogSessionOpenResult OpenSessionResult(string? machineName, int? timeoutMs = null, string? purpose = null, string? logName = null)
+    {
+        return CreateSessionResult(machineName, purpose, logName, timeoutMs);
     }
 
     /// <summary>
@@ -157,19 +243,35 @@ public partial class SearchEvents : Settings
     {
         try
         {
+            return TryGetHostNegativeCacheExpiry(host, out _);
+        }
+        catch (Exception ex)
+        {
+            _logger.WriteVerbose($"Negative cache check failed for '{host}': {ex.Message}");
+            return false;
+        }
+    }
+
+    private static bool TryGetHostNegativeCacheExpiry(string host, out DateTime until)
+    {
+        until = default;
+        try
+        {
             if (string.IsNullOrWhiteSpace(host)) return false;
             string lower = host.ToLowerInvariant();
-            if (_unreachable.TryGetValue(lower, out var until))
+            if (_unreachable.TryGetValue(lower, out until))
             {
                 if (until > DateTime.UtcNow) return true;
                 // Older frameworks don't expose TryRemove(KeyValuePair<,>), fall back to key+out.
                 _unreachable.TryRemove(lower, out _);
             }
+            until = default;
             return false;
         }
         catch (Exception ex)
         {
             _logger.WriteVerbose($"Negative cache check failed for '{host}': {ex.Message}");
+            until = default;
             return false;
         }
     }
@@ -210,4 +312,45 @@ public partial class SearchEvents : Settings
         var cmp = StringComparison.OrdinalIgnoreCase;
         return name == "." || name == "localhost" || name.Equals(Environment.MachineName, cmp) || name.Equals(GetFQDN(), cmp);
     }
+
+    private static EventLogSessionOpenResult SessionSuccess(
+        string? machineName,
+        string targetHost,
+        string purpose,
+        string logName,
+        int timeoutMs,
+        EventLogSession session) =>
+        new()
+        {
+            MachineName = machineName,
+            TargetHost = targetHost,
+            Purpose = purpose,
+            LogName = logName,
+            Status = EventLogSessionOpenStatus.Success,
+            Session = session,
+            TimeoutMs = timeoutMs
+        };
+
+    private static EventLogSessionOpenResult SessionFailure(
+        string? machineName,
+        string targetHost,
+        string purpose,
+        string logName,
+        EventLogSessionOpenStatus status,
+        string errorMessage,
+        int timeoutMs,
+        string? errorType = null,
+        DateTime? cachedUntilUtc = null) =>
+        new()
+        {
+            MachineName = machineName,
+            TargetHost = targetHost,
+            Purpose = purpose,
+            LogName = logName,
+            Status = status,
+            ErrorMessage = errorMessage,
+            ErrorType = errorType ?? status.ToString(),
+            TimeoutMs = timeoutMs,
+            CachedUntilUtc = cachedUntilUtc
+        };
 }


### PR DESCRIPTION
## Summary
- add EventLogDetailsResult and EventLogSessionOpenResult diagnostic contracts to EventViewerX
- expose SearchEvents.GetLogDetailsResult and SearchEvents.OpenSessionResult while preserving existing nullable convenience APIs
- add focused tests for local success, missing-log diagnostics, session reuse, and local session diagnostics

## Why
TestimoX DNS/event-log posture needs structured failure information from EventViewerX instead of duplicating Windows Event Log reader logic in ComputerX.

## Validation
- dotnet.exe restore .\Sources\EventViewerX.sln
- dotnet.exe build .\Sources\EventViewerX.sln -c Debug --no-restore -m:1 -p:BuildInParallel=false
- dotnet.exe test .\Sources\EventViewerX.Tests\EventViewerX.Tests.csproj -c Debug --filter FullyQualifiedName~TestEventLogDetailsResult --no-build -m:1 -p:BuildInParallel=false
